### PR TITLE
Add zipcode functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ Also, don't forget to **Fork & Star the repository if you like it! ❤**
   <li>Choose either format of the code: the .py file (highly recommended) or the jupyter notebook (untested).</li>
   <li>Open the .py file in IDLE. Then click on <strong>Options->Show Line Numbers</strong> in the IDLE Menu Bar.</li>
   <li>Enter your Udemy credentials in the <strong>email</strong> & <strong>password</strong> variables on line 43 & 44 of the code.</li>
-  <li>Enter the location of you webdriver in the path variable on line 52.</li>
-  <li>Choose the appropriate browser in the driver variable on line 53.</li>
+  <li>If located in the USA, enter a zipcode in the <strong>zipcode</strong> variable on line 48 of the code.</li>
+  <li>Enter the location of you webdriver in the path variable on line 56.</li>
+  <li>Choose the appropriate browser in the driver variable on line 57.</li>
   <li>The bot starts scraping the course links from the first <strong>All Courses</strong> page on <a href='https://www.tutorialbar.com/all-courses/page/1'>Tutorial Bar</a> and starts enrolling you to Udemy courses. After it has enrolled you to courses from the first page, it then moves to the next Tutorial Bar page and the cycle continues. However, you can change the starting page in the <strong>page</strong> variable on line 121. (not recommended, except when you are trying to redeem old coupons, which may or may not be valid at this point of time; But sometimes, by a stroke of luck, the coupons may still work!)</li>
 </ol>
 

--- a/udemy_automate_course_enroll_v1.py
+++ b/udemy_automate_course_enroll_v1.py
@@ -54,7 +54,7 @@ Also, enter the location of your webdriver.
 """
 
 path = "..location\msedgedriver.exe" #Replace this string with the path for your webdriver
-driver = webdriver.Edge(path)   # webdriver.Chrome(path) for Google Chrome, webdriver.Firefox(path) for Mozilla Firefox, webdriver.Edge(path) for Microsoft Edge, webdriver.Safari(path) for Apple Safari
+driver = webdriver.Edge(path)   #webdriver.Chrome(path) for Google Chrome, webdriver.Firefox(path) for Mozilla Firefox, webdriver.Edge(path) for Microsoft Edge, webdriver.Safari(path) for Apple Safari
 
 driver.maximize_window()  #Maximizes the browser window since Udemy has a responsive design and the code only works in the maximized layout
 
@@ -122,7 +122,7 @@ def redeemUdemyCourse(url):
         zipcode_element = driver.find_element_by_id("billingAddressSecondaryInput")
         zipcode_element.send_keys(zipcode)
 
-        # After you put the zip code in, the page refreshes itself and disables the enroll button for a split second.
+        #After you put the zip code in, the page refreshes itself and disables the enroll button for a split second.
         time.sleep(1)
     except NoSuchElementException: pass
 

--- a/udemy_automate_course_enroll_v1.py
+++ b/udemy_automate_course_enroll_v1.py
@@ -43,7 +43,6 @@ import time
 email="ENTER_YOUR_UDEMY_REGISTERED_EMAIL_ID_HERE"
 password="ENTER_YOUR_UDEMY_PASSWORD_HERE"
 
-
 """### **If you're in the USA, enter a zipcode here, leave it blank to skip.**"""
 
 zipcode="ENTER_YOUR_ZIPCODE_HERE"

--- a/udemy_automate_course_enroll_v1.py
+++ b/udemy_automate_course_enroll_v1.py
@@ -43,6 +43,10 @@ import time
 email="ENTER_YOUR_UDEMY_REGISTERED_EMAIL_ID_HERE"
 password="ENTER_YOUR_UDEMY_PASSWORD_HERE"
 
+# If you're in the USA, enter a zipcode here, leave it blank to skip.
+
+zipcode="ENTER_YOUR_ZIPCODE_HERE"
+
 """### **Enter the path/location of your webdriver**
 By default, the webdriver for Microsoft Edge browser has been chosen in the code below.
 
@@ -112,6 +116,15 @@ def redeemUdemyCourse(url):
     #Enroll Now 2
     element_present = EC.presence_of_element_located((By.XPATH, "//*[@id=\"udemy\"]/div[1]/div[2]/div/div/div/div[2]/form/div[2]/div/div[4]/button"))
     WebDriverWait(driver, 10).until(element_present)
+
+    #Assume sometimes zip is not required because script was originally pushed without this
+    try:
+        zipcode_element = driver.find_element_by_id("billingAddressSecondaryInput")
+        zipcode_element.send_keys(zipcode)
+
+        # After you put the zip code in, the page refreshes itself and disables the enroll button for a split second.
+        time.sleep(1)
+    except NoSuchElementException: pass
 
     udemyEnroll = driver.find_element_by_xpath("//*[@id=\"udemy\"]/div[1]/div[2]/div/div/div/div[2]/form/div[2]/div/div[4]/button") #Udemy
     udemyEnroll.click()

--- a/udemy_automate_course_enroll_v1.py
+++ b/udemy_automate_course_enroll_v1.py
@@ -43,7 +43,7 @@ import time
 email="ENTER_YOUR_UDEMY_REGISTERED_EMAIL_ID_HERE"
 password="ENTER_YOUR_UDEMY_PASSWORD_HERE"
 
-# If you're in the USA, enter a zipcode here, leave it blank to skip.
+"""### **If you're in the USA, enter a zipcode here, leave it blank to skip.**"""
 
 zipcode="ENTER_YOUR_ZIPCODE_HERE"
 


### PR DESCRIPTION
This pull request is made in response to issue aapatre/Automatic-Udemy-Course-Enroller-GET-PAID-UDEMY-COURSES-for-FREE#4.

My interpretation of the problem was similar to pull request aapatre/Automatic-Udemy-Course-Enroller-GET-PAID-UDEMY-COURSES-for-FREE#5, however, there are a few key differences.

Instead of relying on the length of a user-inputted **zipcode** variable, I use a try block to input the zip code and simply pass if an exception states that the element need not be filled. This will make it more clear if an error is raised because the **zipcode** is wrong and allows for the 1 second sleep to only be done if a **zipcode** is required.

Additionally, solving the problem in this way means the formatting of the **zipcode** variable can be consistent with the **email** & **password** variable formats.  This is better than it being left blank in aapatre/Automatic-Udemy-Course-Enroller-GET-PAID-UDEMY-COURSES-for-FREE#5 for obvious reasons.

I also updated the README to reflect the new **zipcode** variable.