### PR TITLE
Update udemy_enroller_vanilla.py

### DIFF
--- a/udemy_enroller_vanilla.py
+++ b/udemy_enroller_vanilla.py
@@ -162,6 +162,10 @@ def main_function():
         page = page + 1
         loop_run_count = loop_run_count + 1
         
+        if page == 6:
+            print("Last page complete")
+            break
+            
         print("Moving on to the next page of the course list on tutorialbar.com")
 
 main_function()


### PR DESCRIPTION
After the first time, I don't need it to go through all the pages of tutorialbar.com. Most of the coupons past page 5 to 10 are expired or no good. I put this in to only go through the first 6 pages and then stop. This was a quick edit, it would probably be better to put this in the settings.txt.