### PR TITLE
Add udemy course language preferences

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -2,3 +2,4 @@ udemy:
   email: "Example@gmail.com" # Enter your Udemy registered email here
   password: "ExamplePa$$w0rd" # Enter your Udemy password here
   zipcode: "12345" # If Udemy requires a zipcode for your country, enter it here.
+  languages: [] # If you want to limit the languages of courses to claim e.g ["French", "Spanish"]

--- a/udemy_enroller_chrome.py
+++ b/udemy_enroller_chrome.py
@@ -35,6 +35,8 @@ email, password = (
 if "zipcode" in settings["udemy"]:
     zipcode = settings["udemy"]["zipcode"]
 
+languages = settings["udemy"].get("languages")
+
 is_ci_build = strtobool(os.environ.get("CI", "False"))
 chrome_options = None
 if is_ci_build:
@@ -115,6 +117,17 @@ def udemyLogin(email_text, password_text):
 def redeemUdemyCourse(url):
     driver.get(url)
     print("Trying to Enroll for: " + driver.title)
+
+    # If the user has configured languages check it is a supported option
+    if languages:
+        locale_xpath = "//div[@data-purpose='lead-course-locale']"
+        WebDriverWait(driver, 10).until(EC.presence_of_element_located(
+            (By.XPATH, locale_xpath)))
+
+        locale_element = driver.find_element_by_xpath(locale_xpath)
+        if locale_element.text not in languages:
+            print("Course language not wanted: {}".format(locale_element.text))
+            return
 
     # Enroll Now 1
     element_present = EC.presence_of_element_located(

--- a/udemy_enroller_chromium.py
+++ b/udemy_enroller_chromium.py
@@ -27,6 +27,8 @@ email, password = settings["udemy"]["email"], settings["udemy"]["password"]
 if "zipcode" in settings["udemy"]:
     zipcode = settings["udemy"]["zipcode"]
 
+languages = settings["udemy"].get("languages")
+
 driver = webdriver.Chrome(
     ChromeDriverManager(chrome_type=ChromeType.CHROMIUM).install())
 
@@ -93,6 +95,17 @@ def udemyLogin(email_text, password_text):
 def redeemUdemyCourse(url):
     driver.get(url)
     print("Trying to Enroll for: " + driver.title)
+
+    # If the user has configured languages check it is a supported option
+    if languages:
+        locale_xpath = "//div[@data-purpose='lead-course-locale']"
+        WebDriverWait(driver, 10).until(EC.presence_of_element_located(
+            (By.XPATH, locale_xpath)))
+
+        locale_element = driver.find_element_by_xpath(locale_xpath)
+        if locale_element.text not in languages:
+            print("Course language not wanted: {}".format(locale_element.text))
+            return
 
     # Enroll Now 1
     element_present = EC.presence_of_element_located(

--- a/udemy_enroller_edge.py
+++ b/udemy_enroller_edge.py
@@ -26,6 +26,8 @@ email, password = settings["udemy"]["email"], settings["udemy"]["password"]
 if "zipcode" in settings["udemy"]:
     zipcode = settings["udemy"]["zipcode"]
 
+languages = settings["udemy"].get("languages")
+
 driver = webdriver.Edge(EdgeChromiumDriverManager().install())
 
 # Maximizes the browser window since Udemy has a responsive design and the code only works
@@ -91,6 +93,17 @@ def udemyLogin(email_text, password_text):
 def redeemUdemyCourse(url):
     driver.get(url)
     print("Trying to Enroll for: " + driver.title)
+
+    # If the user has configured languages check it is a supported option
+    if languages:
+        locale_xpath = "//div[@data-purpose='lead-course-locale']"
+        WebDriverWait(driver, 10).until(EC.presence_of_element_located(
+            (By.XPATH, locale_xpath)))
+
+        locale_element = driver.find_element_by_xpath(locale_xpath)
+        if locale_element.text not in languages:
+            print("Course language not wanted: {}".format(locale_element.text))
+            return
 
     # Enroll Now 1
     element_present = EC.presence_of_element_located(

--- a/udemy_enroller_firefox.py
+++ b/udemy_enroller_firefox.py
@@ -27,6 +27,8 @@ email, password = settings["udemy"]["email"], settings["udemy"]["password"]
 if "zipcode" in settings["udemy"]:
     zipcode = settings["udemy"]["zipcode"]
 
+languages = settings["udemy"].get("languages")
+
 driver = webdriver.Firefox()
 
 # Maximizes the browser window since Udemy has a responsive design and the code only works
@@ -93,6 +95,17 @@ def udemyLogin(email_text, password_text):
 def redeemUdemyCourse(url):
     driver.get(url)
     print("Trying to Enroll for: " + driver.title)
+
+    # If the user has configured languages check it is a supported option
+    if languages:
+        locale_xpath = "//div[@data-purpose='lead-course-locale']"
+        WebDriverWait(driver, 10).until(EC.presence_of_element_located(
+            (By.XPATH, locale_xpath)))
+
+        locale_element = driver.find_element_by_xpath(locale_xpath)
+        if locale_element.text not in languages:
+            print("Course language not wanted: {}".format(locale_element.text))
+            return
 
     # Enroll Now 1
     element_present = EC.presence_of_element_located(

--- a/udemy_enroller_internet_explorer.py
+++ b/udemy_enroller_internet_explorer.py
@@ -26,6 +26,8 @@ email, password = settings["udemy"]["email"], settings["udemy"]["password"]
 if "zipcode" in settings["udemy"]:
     zipcode = settings["udemy"]["zipcode"]
 
+languages = settings["udemy"].get("languages")
+
 driver = webdriver.Ie(IEDriverManager().install())
 
 # Maximizes the browser window since Udemy has a responsive design and the code only works
@@ -92,6 +94,17 @@ def udemyLogin(email_text, password_text):
 def redeemUdemyCourse(url):
     driver.get(url)
     print("Trying to Enroll for: " + driver.title)
+
+    # If the user has configured languages check it is a supported option
+    if languages:
+        locale_xpath = "//div[@data-purpose='lead-course-locale']"
+        WebDriverWait(driver, 10).until(EC.presence_of_element_located(
+            (By.XPATH, locale_xpath)))
+
+        locale_element = driver.find_element_by_xpath(locale_xpath)
+        if locale_element.text not in languages:
+            print("Course language not wanted: {}".format(locale_element.text))
+            return
 
     # Enroll Now 1
     element_present = EC.presence_of_element_located(

--- a/udemy_enroller_opera.py
+++ b/udemy_enroller_opera.py
@@ -26,6 +26,8 @@ email, password = settings["udemy"]["email"], settings["udemy"]["password"]
 if "zipcode" in settings["udemy"]:
     zipcode = settings["udemy"]["zipcode"]
 
+languages = settings["udemy"].get("languages")
+
 driver = webdriver.Opera(executable_path=OperaDriverManager().install())
 
 # Maximizes the browser window since Udemy has a responsive design and the code only works
@@ -91,6 +93,17 @@ def udemyLogin(email_text, password_text):
 def redeemUdemyCourse(url):
     driver.get(url)
     print("Trying to Enroll for: " + driver.title)
+
+    # If the user has configured languages check it is a supported option
+    if languages:
+        locale_xpath = "//div[@data-purpose='lead-course-locale']"
+        WebDriverWait(driver, 10).until(EC.presence_of_element_located(
+            (By.XPATH, locale_xpath)))
+
+        locale_element = driver.find_element_by_xpath(locale_xpath)
+        if locale_element.text not in languages:
+            print("Course language not wanted: {}".format(locale_element.text))
+            return
 
     # Enroll Now 1
     element_present = EC.presence_of_element_located(

--- a/udemy_enroller_vanilla.py
+++ b/udemy_enroller_vanilla.py
@@ -24,6 +24,9 @@ email, password = settings["udemy"]["email"], settings["udemy"]["password"]
 # This shouldn't have to exist, but ?? here we are
 if "zipcode" in settings["udemy"]:
     zipcode = settings["udemy"]["zipcode"]
+
+languages = settings["udemy"].get("languages")
+
 """### **Enter the path/location of your webdriver**
 By default, the webdriver for Microsoft Edge browser has been chosen in the code below.
 
@@ -101,6 +104,17 @@ def udemyLogin(email_text, password_text):
 def redeemUdemyCourse(url):
     driver.get(url)
     print("Trying to Enroll for: " + driver.title)
+
+    # If the user has configured languages check it is a supported option
+    if languages:
+        locale_xpath = "//div[@data-purpose='lead-course-locale']"
+        WebDriverWait(driver, 10).until(EC.presence_of_element_located(
+            (By.XPATH, locale_xpath)))
+
+        locale_element = driver.find_element_by_xpath(locale_xpath)
+        if locale_element.text not in languages:
+            print("Course language not wanted: {}".format(locale_element.text))
+            return
 
     # Enroll Now 1
     element_present = EC.presence_of_element_located(


### PR DESCRIPTION
Based on the issue highlighted in this ticket: #36 
Add support for the languages you are interested in via settings
Sample of `settings.yaml` where we only want to enroll in English and French courses:
```
udemy:
  email: "Example@gmail.com" 
  password: "ExamplePa$$w0rd"
  zipcode: "12345"
  languages: ["English", "French"]
```

If the languages key is not entered in `settings.yaml` or the language list is empty. All course languages will be added