### PR TITLE
Adding more descriptive error handling

### DIFF
--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -1,0 +1,6 @@
+class RobotException(Exception):
+    """
+    You have been identified as a robot on Udemy site
+    """
+
+    pass

--- a/core/udemy.py
+++ b/core/udemy.py
@@ -5,6 +5,8 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
+from core.exceptions import RobotException
+
 
 class UdemyActions:
     """
@@ -18,23 +20,39 @@ class UdemyActions:
         self.settings = settings
         self.logged_in = False
 
-    def login(self) -> None:
+    def login(self, is_retry=False) -> None:
         """
         Login to your udemy account
+
+        :param bool is_retry: Is this is a login retry and we still have captcha raise RobotException
 
         :return: None
         """
         if not self.logged_in:
             self.driver.get(f"{self.DOMAIN}/join/login-popup/")
+            try:
+                email_element = self.driver.find_element_by_name("email")
+                email_element.send_keys(self.settings.email)
 
-            email_element = self.driver.find_element_by_name("email")
-            email_element.send_keys(self.settings.email)
+                password_element = self.driver.find_element_by_name("password")
+                password_element.send_keys(self.settings.password)
 
-            password_element = self.driver.find_element_by_name("password")
-            password_element.send_keys(self.settings.password)
-
-            self.driver.find_element_by_name("submit").click()
-            self.logged_in = True
+                self.driver.find_element_by_name("submit").click()
+            except NoSuchElementException as e:
+                is_robot = self._check_if_robot()
+                if is_robot and not is_retry:
+                    input(
+                        "Please solve the captcha before proceeding. Hit enter once solved "
+                    )
+                    self.login(is_retry=True)
+                    return
+                elif is_robot and is_retry:
+                    raise RobotException("I am a bot!")
+                else:
+                    raise e
+            else:
+                # TODO: Verify successful login
+                self.logged_in = True
 
     def redeem(self, url: str) -> None:
         """
@@ -44,30 +62,51 @@ class UdemyActions:
         :return: None
         """
         self.driver.get(url)
-        print("Trying to Enroll for: " + self.driver.title)
+
+        course_name = self.driver.title
 
         # If the user has configured languages check it is a supported option
         if self.settings.languages:
             locale_xpath = "//div[@data-purpose='lead-course-locale']"
-            element_text = (WebDriverWait(self.driver, 10).until(
-                EC.presence_of_element_located((By.XPATH, locale_xpath))).text)
+            element_text = (
+                WebDriverWait(self.driver, 10)
+                .until(EC.presence_of_element_located((By.XPATH, locale_xpath)))
+                .text
+            )
 
             if element_text not in self.settings.languages:
-                print("Course language not wanted: {}".format(element_text))
+                print(f"Course language not wanted: {element_text}")
                 return
 
         # Enroll Now 1
         buy_course_button_xpath = "//button[@data-purpose='buy-this-course-button']"
+        # We need to wait for this element to be clickable before checking if already purchased
+        WebDriverWait(self.driver, 10).until(
+            EC.element_to_be_clickable((By.XPATH, buy_course_button_xpath))
+        )
+
+        # Check if already enrolled
+        already_purchased_xpath = (
+            "//div[starts-with(@class, 'buy-box--purchased-text-banner')]"
+        )
+        if self.driver.find_elements_by_xpath(already_purchased_xpath):
+            print(f"Already enrolled in {course_name}")
+            return
+
+        # Click to enroll in the course
         element_present = EC.presence_of_element_located(
-            (By.XPATH, buy_course_button_xpath))
+            (By.XPATH, buy_course_button_xpath)
+        )
         WebDriverWait(self.driver, 10).until(element_present).click()
 
         enroll_button_xpath = "//*[@class='udemy pageloaded']/div[1]/div[2]/div/div/div/div[2]/form/div[2]/div/div[4]/button"
         # Enroll Now 2
-        element_present = EC.presence_of_element_located((
-            By.XPATH,
-            enroll_button_xpath,
-        ))
+        element_present = EC.presence_of_element_located(
+            (
+                By.XPATH,
+                enroll_button_xpath,
+            )
+        )
         WebDriverWait(self.driver, 10).until(element_present)
 
         # Check if zipcode exists before doing this
@@ -75,7 +114,8 @@ class UdemyActions:
             # Assume sometimes zip is not required because script was originally pushed without this
             try:
                 zipcode_element = self.driver.find_element_by_id(
-                    "billingAddressSecondaryInput")
+                    "billingAddressSecondaryInput"
+                )
                 zipcode_element.send_keys(self.settings.zip_code)
 
                 # After you put the zip code in, the page refreshes itself and disables the enroll button for a split
@@ -84,6 +124,37 @@ class UdemyActions:
             except NoSuchElementException:
                 pass
 
-        udemy_enroll_element_2 = self.driver.find_element_by_xpath(
-            enroll_button_xpath)  # Udemy
+        # Make sure the course is Free
+        price_xpath = "//span[@data-purpose='total-price']//span"
+        price_elements = self.driver.find_elements_by_xpath(price_xpath)
+        # We get elements here as one of there are 2 matches for this xpath
+
+        for price_element in price_elements:
+            # We are only interested in the element which is displaying the price details
+            if price_element.is_displayed():
+                _price = price_element.text
+                # Extract the numbers from the price text
+                # This logic should work for different locales and currencies
+                _numbers = "".join(filter(lambda x: x if x.isdigit() else None, _price))
+                if _numbers.isdigit() and int(_numbers) > 0:
+                    print(f"Skipping course as it now costs {_price}: {course_name}")
+                    return
+
+        # Hit the final Enroll now button
+        udemy_enroll_element_2 = self.driver.find_element_by_xpath(enroll_button_xpath)
         udemy_enroll_element_2.click()
+
+        print(f"Successfully enrolled in: {course_name}")
+
+    def _check_if_robot(self) -> bool:
+        """
+        Simply checks if the captcha element is present on login if email/password elements are not
+
+        :return: Bool
+        """
+        is_robot = True
+        try:
+            self.driver.find_element_by_id("px-captcha")
+        except NoSuchElementException:
+            is_robot = False
+        return is_robot

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,8 +1,7 @@
+from selenium.common.exceptions import NoSuchElementException, TimeoutException
 from selenium.webdriver.remote.webdriver import WebDriver
 
-from core import Settings
-from core import TutorialBarScraper
-from core import UdemyActions
+from core import Settings, TutorialBarScraper, UdemyActions, exceptions
 
 
 def redeem_courses(driver: WebDriver, settings: Settings):
@@ -20,16 +19,17 @@ def redeem_courses(driver: WebDriver, settings: Settings):
         for course_link in udemy_course_links:
             try:
                 udemy_actions.redeem(course_link)
-                if settings.is_ci_build:
-                    return
+            except NoSuchElementException as e:
+                print(e)
+            except TimeoutException:
+                print(f"Timeout on link: {course_link}")
             except KeyboardInterrupt:
                 raise
-            except Exception:
+            except (exceptions.RobotException, Exception) as e:
+                print(e)
+                raise e
+            finally:
                 if settings.is_ci_build:
                     return
-                print(
-                    "Unable to enroll for this course either because you have already claimed it or the browser "
-                    "window has been closed!")
 
-        print(
-            "Moving on to the next page of the course list on tutorialbar.com")
+        print("Moving on to the next page of the course list on tutorialbar.com")


### PR DESCRIPTION
This PR is to start addressing the issues in #46 with better error handling

Haven't checked the code for checking the free status of courses in different languages/currencies but I wrote the code so that it extracts the numbers from price and checks they are above 0. Could probably check if all the values in the text are alpha either

Also added check for captcha on login and return control to user to solve it. If they proceed without solving they will see the message as the script exits:
`I am a bot!`

Sample of messages user will see now:

Success:
`Successfully enrolled in: Data Science Master Course 2020 | Udemy`

Already enrolled on a course:
`Already enrolled in The Future of Social Networking - Startups Meet (2021) | Udemy`

No longer free:
`Skipping course as it now costs €11.99: Space Render 2.0: Transform your podcast into videos (2021) | Udemy`

Language not wanted:
`Course language not wanted: Turkish`

Timeout error. Was seeing this for these referral links:
`Timeout on link: https://bit.ly/38nYFy1`