### PR TITLE
Moving env variables to task where the test is being run

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,11 +15,6 @@ jobs:
         python-version: [3.8]
 
     steps:
-    - name: Setting env variables
-      run: echo Setting env varibles
-      env:
-        UDEMY_EMAIL: ${{ secrets.UDEMY_EMAIL }}
-        UDEMY_PASSWORD: ${{ secrets.UDEMY_PASSWORD }}
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
@@ -41,5 +36,8 @@ jobs:
         sudo apt install google-chrome-stable
         sudo apt-get install firefox
     - name: Make sure chrome crawler is working (Attempt to subscribe to 1 course)
+      env:
+        UDEMY_EMAIL: ${{ secrets.UDEMY_EMAIL }}
+        UDEMY_PASSWORD: ${{ secrets.UDEMY_PASSWORD }}
       run: |
         python udemy_enroller_chrome.py


### PR DESCRIPTION
This should fix issue #87

Seems like since the initial commit and now that env variables do not get persisted between the github action steps. 
From everything I've seen though it was never allowed :shrug: but I have some CI runs that say otherwise
So the fix is just to add the environment variable setting to within the same step as the test being run

Opened PR to master as this doesn't change any code or functionality and would be nice to see running :rocket: 