### PR TITLE
Ignore ad domains and wait for price to render

### DIFF
--- a/core/tutorialbar.py
+++ b/core/tutorialbar.py
@@ -11,6 +11,7 @@ class TutorialBarScraper:
     """
 
     DOMAIN = "https://www.tutorialbar.com"
+    AD_DOMAINS = ("https://amzn",)
 
     def __init__(self):
         self.current_page = 0
@@ -31,11 +32,12 @@ class TutorialBarScraper:
 
         print(f"Page: {self.current_page} of {self.last_page} scraped")
         udemy_links = self.gather_udemy_course_links(course_links)
+        filtered_udemy_links = self._filter_ad_domains(udemy_links)
 
-        for counter, course in enumerate(udemy_links):
+        for counter, course in enumerate(filtered_udemy_links):
             print(f"Received Link {counter + 1} : {course}")
 
-        return udemy_links
+        return filtered_udemy_links
 
     def is_first_loop(self) -> bool:
         """
@@ -44,6 +46,22 @@ class TutorialBarScraper:
         :return: boolean showing if this is the first loop of the script
         """
         return self.current_page == 1
+
+    def _filter_ad_domains(self, udemy_links) -> List:
+        """
+        Filter out any known ad domains from the links scraped
+
+        :param list udemy_links: List of urls to filter ad domains from
+        :return: A list of filtered urls
+        """
+        ad_links = set()
+        for link in udemy_links:
+            for ad_domain in self.AD_DOMAINS:
+                if link.startswith(ad_domain):
+                    ad_links.add(link)
+        if ad_links:
+            print(f"Removing ad links from courses: {ad_links}")
+        return list(set(udemy_links) - ad_links)
 
     def get_course_links(self, url: str) -> List:
         """

--- a/core/tutorialbar.py
+++ b/core/tutorialbar.py
@@ -77,7 +77,9 @@ class TutorialBarScraper:
         links = soup.find_all("h3")
         course_links = [link.find("a").get("href") for link in links]
 
-        self.last_page = soup.find("li", class_="next_paginate_link").find_previous_sibling().text
+        self.last_page = (
+            soup.find("li", class_="next_paginate_link").find_previous_sibling().text
+        )
 
         return course_links
 

--- a/core/udemy.py
+++ b/core/udemy.py
@@ -159,7 +159,9 @@ class UdemyActions:
 
         # Make sure the price has loaded
         price_class_loading = "udi-circle-loader"
-        WebDriverWait(self.driver, 10).until_not(EC.presence_of_element_located((By.CLASS_NAME, price_class_loading)))
+        WebDriverWait(self.driver, 10).until_not(
+            EC.presence_of_element_located((By.CLASS_NAME, price_class_loading))
+        )
 
         # Make sure the course is Free
         price_xpath = "//span[@data-purpose='total-price']//span"
@@ -183,8 +185,13 @@ class UdemyActions:
 
         # Wait for success page to load
         success_element_class = "alert-success"
-        (WebDriverWait(self.driver, 10).until(
-            EC.presence_of_element_located((By.CLASS_NAME, success_element_class))).text)
+        (
+            WebDriverWait(self.driver, 10)
+            .until(
+                EC.presence_of_element_located((By.CLASS_NAME, success_element_class))
+            )
+            .text
+        )
 
         print(f"Successfully enrolled in: {course_name}")
         return UdemyStatus.ENROLLED.value

--- a/core/udemy.py
+++ b/core/udemy.py
@@ -157,6 +157,10 @@ class UdemyActions:
             except NoSuchElementException:
                 pass
 
+        # Make sure the price has loaded
+        price_class_loading = "udi-circle-loader"
+        WebDriverWait(self.driver, 10).until_not(EC.presence_of_element_located((By.CLASS_NAME, price_class_loading)))
+
         # Make sure the course is Free
         price_xpath = "//span[@data-purpose='total-price']//span"
         price_elements = self.driver.find_elements_by_xpath(price_xpath)
@@ -176,6 +180,11 @@ class UdemyActions:
         # Hit the final Enroll now button
         udemy_enroll_element_2 = self.driver.find_element_by_xpath(enroll_button_xpath)
         udemy_enroll_element_2.click()
+
+        # Wait for success page to load
+        success_element_class = "alert-success"
+        (WebDriverWait(self.driver, 10).until(
+            EC.presence_of_element_located((By.CLASS_NAME, success_element_class))).text)
 
         print(f"Successfully enrolled in: {course_name}")
         return UdemyStatus.ENROLLED.value


### PR DESCRIPTION
Added removal of ad domains from scraped urls
At the moment this is a list and just contains `https://amzn`

Also fix for the price rendering slowly sometimes
We now wait for the loader to disappear before proceeding to checking if the course is Free.

Additionally added in check that we have enrolled and successfully reached the confirmation screen.
Think we were hitting the checkout button and not giving the request a chance to fire in some instances.

Fixes issues raised in the comments of #109 