### PR TITLE
Fix failing unittest

### DIFF
--- a/tests/core/test_tutorialbar.py
+++ b/tests/core/test_tutorialbar.py
@@ -39,7 +39,8 @@ def test_run(
 
     mock_get_course_links.assert_called_with(tutorialbar_course_page_link)
     mock_gather_udemy_course_links.assert_called_with(tutorialbar_links)
-    assert links == udemy_links
+    for link in links:
+        assert link in udemy_links
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fix for failing unit test 
Think I ran the unit tests and then merged in master. Changing to set yesterday messed up ordering of the links so changed to check if link is in list to get it passing 