### PR TITLE
Adding exit script after X cache hits in a row

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -14,7 +14,10 @@ logger = logging.getLogger("udemy_enroller")
 
 
 def _redeem_courses(
-    driver: WebDriver, settings: Settings, max_pages: Union[int, None]
+    driver: WebDriver,
+    settings: Settings,
+    max_pages: Union[int, None],
+    cache_hit_limit: int,
 ) -> None:
     """
     Method to scrape courses from tutorialbar.com and enroll in them on udemy
@@ -22,12 +25,16 @@ def _redeem_courses(
     :param WebDriver driver: Webdriver used to enroll in Udemy courses
     :param Settings settings: Core settings used for Udemy
     :param int max_pages: Max pages to scrape from tutorialbar.com
+    :param int cache_hit_limit: If we hit the cache this many times in a row we exit the script
     :return:
     """
     cache = CourseCache()
     tb_scraper = TutorialBarScraper(max_pages)
     udemy_actions = UdemyActions(driver, settings)
     udemy_actions.login()  # login once outside while loop
+
+    current_cache_hits = 0
+
     while True:
         # Check if we should exit the loop
         if not tb_scraper.script_should_run():
@@ -39,8 +46,12 @@ def _redeem_courses(
                 if course_link not in cache:
                     status = udemy_actions.redeem(course_link)
                     cache.add(course_link, status)
+                    # Reset cache hit count as we haven't scraped this page before
+                    current_cache_hits = 0
                 else:
                     logger.info(f"In cache: {course_link}")
+                    # Increment the cache hit count since this link is in the cache
+                    current_cache_hits += 1
             except NoSuchElementException as e:
                 logger.error(e)
             except TimeoutException:
@@ -61,11 +72,32 @@ def _redeem_courses(
                     logger.info("Ending test")
                     return
 
+        # Exit the loop if we have reached the cache hit limit
+        if _reached_cache_hit_limit(cache_hit_limit, current_cache_hits):
+            return
+
         logger.info("Moving on to the next page of the course list on tutorialbar.com")
 
 
+def _reached_cache_hit_limit(cache_hit_limit, cache_hits) -> bool:
+    """
+    Check if we have reached the cache hit limit
+
+    :param int cache_hit_limit: Limit on the number of cache hits in a row to allow
+    :param int cache_hits: Current number of cache hits in a row
+    :return:
+    """
+    reached_hit_limit = cache_hit_limit <= cache_hits
+    if reached_hit_limit:
+        logger.info(f"Hit cache {cache_hits} times in a row. Exiting script")
+    return reached_hit_limit
+
+
 def redeem_courses(
-    driver: WebDriver, settings: Settings, max_pages: Union[int, None]
+    driver: WebDriver,
+    settings: Settings,
+    max_pages: Union[int, None],
+    cache_hit_limit: int,
 ) -> None:
     """
     Wrapper of _redeem_courses so we always close browser on completion
@@ -73,10 +105,11 @@ def redeem_courses(
     :param WebDriver driver: Webdriver used to enroll in Udemy courses
     :param Settings settings: Core settings used for Udemy
     :param int max_pages: Max pages to scrape from tutorialbar.com
+    :param int cache_hit_limit: If we hit the cache this many times in a row we exit the script
     :return:
     """
     try:
-        _redeem_courses(driver, settings, max_pages)
+        _redeem_courses(driver, settings, max_pages, cache_hit_limit)
     finally:
         logger.info("Closing browser")
         driver.quit()

--- a/udemy_enroller.py
+++ b/udemy_enroller.py
@@ -11,12 +11,18 @@ from core import ALL_VALID_BROWSER_STRINGS, DriverManager, Settings
 from core.utils import redeem_courses
 
 
-def run(browser: str, max_pages: Union[int, None], driver: WebDriver = None):
+def run(
+    browser: str,
+    max_pages: Union[int, None],
+    cache_hit_limit: int,
+    driver: WebDriver = None,
+):
     """
     Run the udemy enroller script
 
     :param str browser: Name of the browser we want to create a driver for
     :param int or None max_pages: Max number of pages to scrape from tutorialbar.com
+    :param int cache_hit_limit: If we hit the cache this many times in a row we exit the script
     :param WebDriver driver:
     :return:
     """
@@ -24,7 +30,7 @@ def run(browser: str, max_pages: Union[int, None], driver: WebDriver = None):
     if driver is None:
         dm = DriverManager(browser=browser, is_ci_build=settings.is_ci_build)
         driver = dm.driver
-    redeem_courses(driver, settings, max_pages)
+    redeem_courses(driver, settings, max_pages, cache_hit_limit)
 
 
 def parse_args(browser=None, use_manual_driver=False) -> Namespace:
@@ -50,6 +56,12 @@ def parse_args(browser=None, use_manual_driver=False) -> Namespace:
         default=None,
         help="Max pages to scrape from tutorialbar.com",
     )
+    parser.add_argument(
+        "--cache-hits",
+        type=int,
+        default=12,
+        help="If we hit the cache this number of times in a row we will exit the script",
+    )
 
     args = parser.parse_args()
 
@@ -62,4 +74,4 @@ def parse_args(browser=None, use_manual_driver=False) -> Namespace:
 if __name__ == "__main__":
     args = parse_args()
     if args:
-        run(args.browser, args.max_pages)
+        run(args.browser, args.max_pages, args.cache_hits)

--- a/udemy_enroller_chrome.py
+++ b/udemy_enroller_chrome.py
@@ -5,4 +5,4 @@ from udemy_enroller import parse_args, run
 
 if __name__ == "__main__":
     args = parse_args("chrome")
-    run(args.browser, args.max_pages)
+    run(args.browser, args.max_pages, args.cache_hits)

--- a/udemy_enroller_chromium.py
+++ b/udemy_enroller_chromium.py
@@ -5,4 +5,4 @@ from udemy_enroller import parse_args, run
 
 if __name__ == "__main__":
     args = parse_args("chromium")
-    run(args.browser, args.max_pages)
+    run(args.browser, args.max_pages, args.cache_hits)

--- a/udemy_enroller_edge.py
+++ b/udemy_enroller_edge.py
@@ -5,4 +5,4 @@ from udemy_enroller import parse_args, run
 
 if __name__ == "__main__":
     args = parse_args("edge")
-    run(args.browser, args.max_pages)
+    run(args.browser, args.max_pages, args.cache_hits)

--- a/udemy_enroller_firefox.py
+++ b/udemy_enroller_firefox.py
@@ -6,4 +6,4 @@ from udemy_enroller import parse_args, run
 
 if __name__ == "__main__":
     args = parse_args("firefox")
-    run(args.browser, args.max_pages)
+    run(args.browser, args.max_pages, args.cache_hits)

--- a/udemy_enroller_internet_explorer.py
+++ b/udemy_enroller_internet_explorer.py
@@ -5,4 +5,4 @@ from udemy_enroller import parse_args, run
 
 if __name__ == "__main__":
     args = parse_args("internet_explorer")
-    run(args.browser, args.max_pages)
+    run(args.browser, args.max_pages, args.cache_hits)

--- a/udemy_enroller_opera.py
+++ b/udemy_enroller_opera.py
@@ -5,4 +5,4 @@ from udemy_enroller import parse_args, run
 
 if __name__ == "__main__":
     args = parse_args("opera")
-    run(args.browser, args.max_pages)
+    run(args.browser, args.max_pages, args.cache_hits)

--- a/udemy_enroller_vanilla.py
+++ b/udemy_enroller_vanilla.py
@@ -31,4 +31,4 @@ if __name__ == "__main__":
     # in the maximized layout
     driver.maximize_window()
 
-    run(args.browser, args.max_pages, driver=driver)
+    run(args.browser, args.max_pages, args.cache_hits, driver=driver)


### PR DESCRIPTION
# Description

Exit the script if we hit the cache X times in a row. Default is 12 since we have 12 links per page at the moment.
We can pass args via command line to update if you want the limit to be larger

Fixes #94 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Running the scripts and checking it exits after the set number of cache hits in a row

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have added tests that prove my fix is effective or that my feature works (Optional)
- [x] New and existing unit tests pass locally with my changes (Optional)
