### PR TITLE
Remove comidoc and add DiscUdemy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to
 
 ### Added
 
-- New coupon source from comidoc.net
+- New coupon source from discudemy.com
 - Refactored to have generic scrapers and manager
 - Improved performance (asyncio)
 - Packaged and published to PyPI
-- Added cli args --debug, --tuorialbar, --comidoc
+- Added cli args --debug, --tutorialbar, --discudemy
 - Removed unpopular cli arg -> --cache-hits
 - Write settings/cache to home folder so we can persist settings between versions (installed from PyPI)
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Do you want to LEARN NEW STUFF for FREE? Don't worry, with the power of
 web-scraping and automation, this script will find the necessary Udemy Coupons
 &amp; enroll you to PAID UDEMY COURSES, ABSOLUTELY FREE!
 
-The code scrapes course links and coupons from
-[tutorialbar.com](https://tutorialbar.com)
+The code scrapes course links and coupons from:
+ - [tutorialbar.com](https://tutorialbar.com)
+ - [discudemy.com](https://discudemy.com)
 
 In case of any bugs or issues, please open an issue in github.
 
@@ -101,7 +102,7 @@ get all the requirements installed in one go. Similar instructions applies for p
 3 . The script can be passed arguments:
 - `--help`: View full list of arguments available
 - `--browser=<BROWSER_NAME>`: Run with a specific browser 
-- `--comidoc`: Run the comidoc scraper only
+- `--discudemy`: Run the discudemy scraper only
 - `--tutorialbar`: Run the tutorialbar scraper only
 - `--max-pages=<NUMBER>`: Max number of pages to scrape from sites before exiting the script (default is 5)
 - `--debug`: Enable debug logging
@@ -110,9 +111,9 @@ get all the requirements installed in one go. Similar instructions applies for p
 - `udemy_enroller --browser=firefox`
 
 5 . The bot starts scraping the course links from the first **All Courses** page
-on [Tutorial Bar](https://www.tutorialbar.com/all-courses/page/1) and [Comidoc](https://www.comidoc.net/coupons) and starts
+on [Tutorial Bar](https://www.tutorialbar.com/all-courses/page/1) and [DiscUdemy](https://www.discudemy.com/all) and starts
 enrolling you to Udemy courses. After it has enrolled you to courses from the
-first page, it then moves to the next Tutorial Bar page and the cycle continues.
+first page, it then moves to the next site page and the cycle continues.
 
 - Stop the script by pressing ctrl+c in terminal to stop the enrollment process.
 
@@ -132,7 +133,7 @@ which of course I got for free! :)
 
 ### 2. How does the bot work?
 
-The bot retrieves coupon links from Tutorial Bar's list to cut the prices and
+The bot retrieves coupon links from Tutorial Bar's and DiscUdemy list to cut the prices and
 then uses Selenium's Browser automation features to login and enroll to the
 courses. Think of it this way: Epic Games & other clients like Steam provide you
 a handful of games each week, for free; Only in this case, we need a coupon code

--- a/core/runner.py
+++ b/core/runner.py
@@ -71,7 +71,7 @@ def redeem_courses(
     driver: WebDriver,
     settings: Settings,
     tutorialbar_enabled: bool,
-    comidoc_enabled: bool,
+    discudemy_enabled: bool,
     max_pages: Union[int, None],
 ) -> None:
     """
@@ -80,12 +80,12 @@ def redeem_courses(
     :param WebDriver driver: Webdriver used to enroll in Udemy courses
     :param Settings settings: Core settings used for Udemy
     :param bool tutorialbar_enabled: Boolean signifying if tutorialbar scraper should run
-    :param bool comidoc_enabled: Boolean signifying if comidoc scraper should run
+    :param bool discudemy_enabled: Boolean signifying if discudemy scraper should run
     :param int max_pages: Max pages to scrape from sites (if pagination exists)
     :return:
     """
     try:
-        scrapers = ScraperManager(tutorialbar_enabled, comidoc_enabled, max_pages)
+        scrapers = ScraperManager(tutorialbar_enabled, discudemy_enabled, max_pages)
         _redeem_courses(driver, settings, scrapers)
     except exceptions.LoginException as e:
         logger.error(str(e))

--- a/core/scrapers/manager.py
+++ b/core/scrapers/manager.py
@@ -2,17 +2,19 @@ import asyncio
 from functools import reduce
 from typing import List
 
-from core.scrapers.comidoc import ComidocScraper
+from core.scrapers.discudemy import DiscUdemyScraper
 from core.scrapers.tutorialbar import TutorialBarScraper
 
 
 class ScraperManager:
-    def __init__(self, tutorialbar_enabled, comidoc_enabled, max_pages):
+    def __init__(self, tutorialbar_enabled, discudemy_enabled, max_pages):
         self.tutorialbar_scraper = TutorialBarScraper(
             tutorialbar_enabled, max_pages=max_pages
         )
-        self.comidoc_scraper = ComidocScraper(comidoc_enabled, max_pages=max_pages)
-        self._scrapers = (self.tutorialbar_scraper, self.comidoc_scraper)
+        self.discudemy_scraper = DiscUdemyScraper(
+            discudemy_enabled, max_pages=max_pages
+        )
+        self._scrapers = (self.tutorialbar_scraper, self.discudemy_scraper)
 
     async def run(self) -> List:
         """

--- a/core/scrapers/tutorialbar.py
+++ b/core/scrapers/tutorialbar.py
@@ -116,7 +116,7 @@ class TutorialBarScraper(BaseScraper):
 
     async def gather_udemy_course_links(self, courses: List[str]):
         """
-        Threaded fetching of the udemy course links from tutorialbar.com
+        Async fetching of the udemy course links from tutorialbar.com
 
         :param list courses: A list of tutorialbar.com course links we want to fetch the udemy links for
         :return: list of udemy links

--- a/scripts/udemy_enroller.py
+++ b/scripts/udemy_enroller.py
@@ -24,23 +24,23 @@ def enable_debug_logging() -> None:
 
 def determine_if_scraper_enabled(
     tutorialbar_enabled: bool,
-    comidoc_enabled: bool,
+    discudemy_enabled: bool,
 ) -> Tuple[bool, bool]:
     """
     Determine what scrapers should be enabled and disabled
 
     :return: tuple containing boolean of what scrapers should run
     """
-    if not tutorialbar_enabled and not comidoc_enabled:
+    if not tutorialbar_enabled and not discudemy_enabled:
         # Set both to True since user has not enabled a specific scraper i.e Run all scrapers
-        tutorialbar_enabled, comidoc_enabled = True, True
-    return tutorialbar_enabled, comidoc_enabled
+        tutorialbar_enabled, discudemy_enabled = True, True
+    return tutorialbar_enabled, discudemy_enabled
 
 
 def run(
     browser: str,
     tutorialbar_enabled: bool,
-    comidoc_enabled: bool,
+    discudemy_enabled: bool,
     max_pages: Union[int, None],
 ):
     """
@@ -48,13 +48,15 @@ def run(
 
     :param str browser: Name of the browser we want to create a driver for
     :param bool tutorialbar_enabled:
-    :param bool comidoc_enabled:
+    :param bool discudemy_enabled:
     :param int max_pages: Max pages to scrape from sites (if pagination exists)
     :return:
     """
     settings = Settings()
     dm = DriverManager(browser=browser, is_ci_build=settings.is_ci_build)
-    redeem_courses(dm.driver, settings, tutorialbar_enabled, comidoc_enabled, max_pages)
+    redeem_courses(
+        dm.driver, settings, tutorialbar_enabled, discudemy_enabled, max_pages
+    )
 
 
 def parse_args(browser=None) -> Namespace:
@@ -80,10 +82,10 @@ def parse_args(browser=None) -> Namespace:
         help="Run tutorialbar scraper",
     )
     parser.add_argument(
-        "--comidoc",
+        "--discudemy",
         action="store_true",
         default=False,
-        help="Run comidoc scraper",
+        help="Run discudemy scraper",
     )
     parser.add_argument(
         "--max-pages",
@@ -110,7 +112,7 @@ def main():
     if args:
         if args.debug:
             enable_debug_logging()
-        tutorialbar_enabled, comidoc_enabled = determine_if_scraper_enabled(
-            args.tutorialbar, args.comidoc
+        tutorialbar_enabled, discudemy_enabled = determine_if_scraper_enabled(
+            args.tutorialbar, args.discudemy
         )
-        run(args.browser, tutorialbar_enabled, comidoc_enabled, args.max_pages)
+        run(args.browser, tutorialbar_enabled, discudemy_enabled, args.max_pages)


### PR DESCRIPTION
# Description

So as the title suggests comidoc changed again so there's no point in using it anymore.
I've added a new scraper for DiscUdemy to make up for the fact we are losing comidoc :smile: 
Used this as a source for new site suppport: https://github.com/MasterBrian99/Free-Courses-For-Everyone

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Executed locally and working as expected. 
Just a note that discudemy doesn't only have discounted courses listed but also free courses hence there can be varying numbers scraped from each page. We only take courses that match the pattern ending with `couponCode=<COUPONCODE>`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have added tests that prove my fix is effective or that my feature works (Optional)
- [x] New and existing unit tests pass locally with my changes (Optional)
