### PR TITLE
Adding CLI option to delete settings file

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Props to Davidd Sargent for making a super simple video tutorial. If you prefer 
 - `--discudemy`: Run the discudemy scraper only
 - `--tutorialbar`: Run the tutorialbar scraper only
 - `--max-pages=<NUMBER>`: Max number of pages to scrape from sites before exiting the script (default is 5)
+- `--delete-settings`: Delete existing settings file
 - `--debug`: Enable debug logging
 
 4 . Run the chosen script in terminal like so:

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -61,7 +61,7 @@ def test_settings(email, password, zip_code, languages, categories, save, file_n
     ):
         with mock.patch("getpass.getpass", return_value=password):
             settings_path = os.path.join(get_app_dir(), f"test_tmp/{file_name}")
-            settings = Settings(settings_path)
+            settings = Settings(False, settings_path)
             assert settings.email == email
             assert settings.password == password
             assert settings.zip_code == zip_code
@@ -86,7 +86,7 @@ def test_settings(email, password, zip_code, languages, categories, save, file_n
                         else categories
                     )
                 # Load settings just created
-                Settings(settings_path)
+                Settings(False, settings_path)
             else:
                 assert os.path.isdir(settings_path) is False
 
@@ -146,10 +146,10 @@ def test_load_existing_settings(
     ):
         with mock.patch("getpass.getpass", return_value=password):
             settings_path = f"test_tmp/{file_name}"
-            Settings(settings_path)
+            Settings(False, settings_path)
 
     # Load existing settings
-    settings = Settings(settings_path)
+    settings = Settings(False, settings_path)
     assert settings.email == email
     assert settings.password == password
     assert settings.zip_code == zip_code
@@ -181,7 +181,7 @@ def test_load_ci_settings(_, monkeypatch, is_ci_run, email, password):
     monkeypatch.setenv("CI_TEST", str(is_ci_run))
     monkeypatch.setenv("UDEMY_EMAIL", email)
     monkeypatch.setenv("UDEMY_PASSWORD", password)
-    settings = Settings("")
+    settings = Settings(False, "")
     if is_ci_run:
         assert settings.email == email
         assert settings.password == password

--- a/udemy_enroller/cli.py
+++ b/udemy_enroller/cli.py
@@ -42,6 +42,7 @@ def run(
     tutorialbar_enabled: bool,
     discudemy_enabled: bool,
     max_pages: Union[int, None],
+    delete_settings: bool,
 ):
     """
     Run the udemy enroller script
@@ -50,9 +51,10 @@ def run(
     :param bool tutorialbar_enabled:
     :param bool discudemy_enabled:
     :param int max_pages: Max pages to scrape from sites (if pagination exists)
+    :param bool delete_settings: Determines if we should delete old settings file
     :return:
     """
-    settings = Settings()
+    settings = Settings(delete_settings)
     dm = DriverManager(browser=browser, is_ci_build=settings.is_ci_build)
     redeem_courses(
         dm.driver, settings, tutorialbar_enabled, discudemy_enabled, max_pages
@@ -94,6 +96,12 @@ def parse_args(browser=None) -> Namespace:
         help=f"Max pages to scrape from sites (if pagination exists) (Default is 5)",
     )
     parser.add_argument(
+        "--delete-settings",
+        action="store_true",
+        default=False,
+        help="Delete any existing settings file",
+    )
+    parser.add_argument(
         "--debug",
         action="store_true",
         help="Enable debug logging",
@@ -115,4 +123,10 @@ def main():
         tutorialbar_enabled, discudemy_enabled = determine_if_scraper_enabled(
             args.tutorialbar, args.discudemy
         )
-        run(args.browser, tutorialbar_enabled, discudemy_enabled, args.max_pages)
+        run(
+            args.browser,
+            tutorialbar_enabled,
+            discudemy_enabled,
+            args.max_pages,
+            args.delete_settings,
+        )

--- a/udemy_enroller/settings.py
+++ b/udemy_enroller/settings.py
@@ -16,7 +16,7 @@ class Settings:
     Contains all logic related to the scripts settings
     """
 
-    def __init__(self, settings_path="settings.yaml"):
+    def __init__(self, delete_settings, settings_path="settings.yaml"):
         self.email = None
         self.password = None
         self.zip_code = None
@@ -25,6 +25,8 @@ class Settings:
 
         self._settings_path = os.path.join(get_app_dir(), settings_path)
         self.is_ci_build = strtobool(os.environ.get("CI_TEST", "False"))
+        if delete_settings:
+            self.delete()
         self._init_settings()
 
     def _init_settings(self) -> None:
@@ -169,3 +171,19 @@ class Settings:
             logger.info(f"Saved your settings in {self._settings_path}")
         else:
             logger.info("Not saving your settings as requested")
+
+    def delete(self) -> None:
+        """
+        Delete the settings file
+
+        :return: None
+        """
+        if os.path.isfile(self._settings_path):
+            delete_settings = input(
+                "Please confirm that you want to delete your saved settings (Y/N): "
+            )
+            if delete_settings.lower() == "y":
+                os.remove(self._settings_path)
+                logger.info(f"Settings file deleted: {self._settings_path}")
+        else:
+            logger.info("No settings to delete")


### PR DESCRIPTION
# Description

Add --delete-settings option so we can delete existing settings file if it exists

Fixes #222

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have added tests that prove my fix is effective or that my feature works (Optional)
- [x] New and existing unit tests pass locally with my changes (Optional)
