### PR TITLE
Save settings and prompt for storing email/password

### DIFF
--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -9,42 +9,46 @@ from udemy_enroller.utils import get_app_dir
 
 
 @pytest.mark.parametrize(
-    "email,password,zip_code,languages,categories,save,file_name",
+    "email,should_save_email,password,should_save_password,zip_code,languages,categories,file_name",
     [
         (
             "test4@mail.com",
+            "Y",
             "dskalksdl678",
+            "Y",
             "12345",
             None,
             None,
-            "Y",
             "test_settings1.yaml",
         ),
         (
             "test6@mail.com",
+            "Y",
             "$6237556^^$",
+            "Y",
             "12345",
             "English,French",
             None,
-            "Y",
             "test_settings2.yaml",
         ),
         (
             "test9@mail.com",
+            "Y",
             "$62371231236^^$",
+            "Y",
             "12345",
             "English,French",
             "Development,Art",
-            "Y",
             "test_settings5.yaml",
         ),
         (
             "cultest8lzie@mail.com",
+            "Y",
             "43223*&6",
+            "Y",
             "12345",
             None,
             None,
-            "N",
             "no_save_test_settings.yaml",
         ),
     ],
@@ -55,9 +59,26 @@ from udemy_enroller.utils import get_app_dir
         "create settings all languages and don't save",
     ),
 )
-def test_settings(email, password, zip_code, languages, categories, save, file_name):
+def test_settings(
+    email,
+    should_save_email,
+    password,
+    should_save_password,
+    zip_code,
+    languages,
+    categories,
+    file_name,
+):
     with mock.patch(
-        "builtins.input", side_effect=[email, zip_code, languages, categories, save]
+        "builtins.input",
+        side_effect=[
+            email,
+            should_save_email,
+            should_save_password,
+            zip_code,
+            languages,
+            categories,
+        ],
     ):
         with mock.patch("getpass.getpass", return_value=password):
             settings_path = os.path.join(get_app_dir(), f"test_tmp/{file_name}")
@@ -68,67 +89,106 @@ def test_settings(email, password, zip_code, languages, categories, save, file_n
             assert settings.languages == [] if languages is None else languages
             assert settings.categories == [] if categories is None else categories
 
-            if save.upper() == "Y":
-                yaml = YAML()
-                with open(settings_path) as f:
-                    settings = yaml.load(f)
+            yaml = YAML()
+            with open(settings_path) as f:
+                settings = yaml.load(f)
+                if should_save_email.upper() == "Y":
                     assert settings["udemy"]["email"] == email
+                else:
+
+                    assert settings["udemy"]["email"] is None
+                if should_save_password.upper() == "Y":
                     assert settings["udemy"]["password"] == password
-                    assert settings["udemy"]["zipcode"] == zip_code
-                    assert (
-                        settings["udemy"]["languages"] == []
-                        if languages is None
-                        else ",".join(languages)
-                    )
-                    assert (
-                        settings["udemy"]["categories"] == []
-                        if categories is None
-                        else categories
-                    )
-                # Load settings just created
-                Settings(False, settings_path)
-            else:
-                assert os.path.isdir(settings_path) is False
+                else:
+                    assert settings["udemy"]["password"] is None
+
+                assert settings["udemy"]["zipcode"] == zip_code
+                assert (
+                    settings["udemy"]["languages"] == []
+                    if languages is None
+                    else ",".join(languages)
+                )
+                assert (
+                    settings["udemy"]["categories"] == []
+                    if categories is None
+                    else categories
+                )
+            # Load settings just created
+            Settings(False, settings_path)
 
 
 @pytest.mark.parametrize(
-    "email,password,zip_code,languages,categories,save,file_name",
+    "email,should_save_email,password,should_save_password,zip_code,languages,categories,file_name",
     [
         (
             "test9@mail.com",
+            "Y",
             "uherwh834",
+            "Y",
             "12345",
             None,
             None,
-            "Y",
             "test_load_existing_settings1.yaml",
         ),
         (
             "test80@mail.com",
+            "Y",
             "jkajsdsad",
+            "Y",
             "None",
             "Italian",
             None,
-            "Y",
             "test_load_existing_settings9.yaml",
         ),
         (
             "test10@mail.com",
+            "Y",
             "234sdfs",
+            "Y",
             "None",
             "English",
             "Development,Art",
-            "Y",
             "test_load_existing_settings2.yaml",
         ),
         (
             "test11@mail.com",
+            "Y",
             "frtuhrfty234",
+            "Y",
             "788192",
             "French,German",
             None,
+            "test_load_existing_settings4.yaml",
+        ),
+        (
+            "test54@mail.com",
+            "N",
+            "op123890",
             "Y",
+            "788192",
+            "French,German",
+            None,
             "test_load_existing_settings3.yaml",
+        ),
+        (
+            "test55@mail.com",
+            "Y",
+            "ajsdkljaklsdj",
+            "N",
+            "1231",
+            "French,German",
+            None,
+            "test_load_existing_settings5.yaml",
+        ),
+        (
+            "test70@mail.com",
+            "N",
+            "sda123efg",
+            "N",
+            "1231",
+            "English,German",
+            None,
+            "test_load_existing_settings6.yaml",
         ),
     ],
     ids=(
@@ -136,13 +196,31 @@ def test_settings(email, password, zip_code, languages, categories, save, file_n
         "load existing settings no categories",
         "load existing settings no zipcode",
         "load existing settings full",
+        "load existing settings no email",
+        "load existing settings no password",
+        "load existing settings no email or pasword",
     ),
 )
 def test_load_existing_settings(
-    email, password, zip_code, languages, categories, save, file_name
+    email,
+    should_save_email,
+    password,
+    should_save_password,
+    zip_code,
+    languages,
+    categories,
+    file_name,
 ):
     with mock.patch(
-        "builtins.input", side_effect=[email, zip_code, languages, categories, save]
+        "builtins.input",
+        side_effect=[
+            email,
+            should_save_email,
+            should_save_password,
+            zip_code,
+            languages,
+            categories,
+        ],
     ):
         with mock.patch("getpass.getpass", return_value=password):
             settings_path = f"test_tmp/{file_name}"
@@ -150,8 +228,14 @@ def test_load_existing_settings(
 
     # Load existing settings
     settings = Settings(False, settings_path)
-    assert settings.email == email
-    assert settings.password == password
+    if should_save_email.upper() == "Y":
+        assert settings.email == email
+    else:
+        assert settings.email is None
+    if should_save_password.upper() == "Y":
+        assert settings.password == password
+    else:
+        assert settings.password is None
     assert settings.zip_code == zip_code
     assert settings.languages == [] if languages is None else languages
     assert settings.categories == [] if categories is None else categories

--- a/udemy_enroller/settings.py
+++ b/udemy_enroller/settings.py
@@ -1,4 +1,3 @@
-import bcrypt
 import getpass
 import os.path
 from distutils.util import strtobool

--- a/udemy_enroller/settings.py
+++ b/udemy_enroller/settings.py
@@ -1,7 +1,8 @@
+import bcrypt
 import getpass
 import os.path
 from distutils.util import strtobool
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from ruamel.yaml import YAML, dump
 
@@ -24,6 +25,8 @@ class Settings:
         self.categories = []
 
         self._settings_path = os.path.join(get_app_dir(), settings_path)
+        self._should_store_email = False
+        self._should_store_password = False
         self.is_ci_build = strtobool(os.environ.get("CI_TEST", "False"))
         if delete_settings:
             self.delete()
@@ -81,35 +84,47 @@ class Settings:
 
         :return:
         """
-        self.email = self._get_email()
-        self.password = self._get_password()
+        self.email, self._should_store_email = self._get_email()
+        self.password, self._should_store_password = self._get_password()
         self.zip_code = self._get_zip_code()
         self.languages = self._get_languages()
         self.categories = self._get_categories()
 
-    def _get_email(self) -> str:
+    def _get_email(self, prompt_save=True) -> Tuple[str, bool]:
         """
         Get input from user on the email to use for udemy
 
-        :return: The users udemy email
+        :return: The users udemy email and if it should be saved
         """
         email = input("Please enter your udemy email address: ")
         if len(email) == 0:
             logger.warning("You must provide your email")
             return self._get_email()
-        return email
+        if prompt_save:
+            save_email = input("Do you want to save your email for future use (Y/N): ")
+            should_store = save_email.lower() == "y"
+        else:
+            should_store = False
+        return email, should_store
 
-    def _get_password(self) -> str:
+    def _get_password(self, prompt_save=True) -> Tuple[str, bool]:
         """
         Get input from user on the password to use for udemy
 
-        :return: The users udemy password
+        :return: The users udemy password and if it should be saved
         """
         password = getpass.getpass(prompt="Please enter your udemy password: ")
         if len(password) == 0:
             logger.warning("You must provide your password")
             return self._get_password()
-        return password
+        if prompt_save:
+            save_password = input(
+                "Do you want to save your password for future use (Y/N): "
+            )
+            should_store = save_password.lower() == "y"
+        else:
+            should_store = False
+        return password, should_store
 
     @staticmethod
     def _get_zip_code() -> str:
@@ -155,22 +170,29 @@ class Settings:
 
         :return:
         """
-        yaml_structure = {}
-        save_settings = input("Do you want to save settings for future use (Y/N): ")
-        if save_settings.lower() == "y":
-            yaml_structure["udemy"] = {
-                "email": str(self.email),
-                "password": str(self.password),
+        yaml_structure = {
+            "udemy": {
+                "email": str(self.email) if self._should_store_email else None,
+                "password": str(self.password) if self._should_store_password else None,
                 "zipcode": str(self.zip_code),
                 "languages": self.languages,
                 "categories": self.categories,
             }
+        }
 
-            with open(self._settings_path, "w+") as f:
-                dump(yaml_structure, stream=f)
-            logger.info(f"Saved your settings in {self._settings_path}")
-        else:
-            logger.info("Not saving your settings as requested")
+        with open(self._settings_path, "w+") as f:
+            dump(yaml_structure, stream=f)
+        logger.info(f"Saved your settings in {self._settings_path}")
+
+        # Log some details for the user
+        if not self._should_store_email:
+            logger.info(f"Your email has not been saved to settings.")
+        if not self._should_store_password:
+            logger.info("Your password has not been saved to settings.")
+        if not self._should_store_email or self._should_store_password:
+            logger.info(
+                "You will be prompted to enter your email/password again when the cookie expires"
+            )
 
     def delete(self) -> None:
         """
@@ -187,3 +209,19 @@ class Settings:
                 logger.info(f"Settings file deleted: {self._settings_path}")
         else:
             logger.info("No settings to delete")
+
+    def prompt_email(self) -> None:
+        """
+        Prompt for Udemy email only. Does not prompt for saving
+
+        :return: None
+        """
+        self.email, _ = self._get_email(prompt_save=False)
+
+    def prompt_password(self) -> None:
+        """
+        Prompt for Udemy password only. Does not prompt for saving
+
+        :return: None
+        """
+        self.password, _ = self._get_password(prompt_save=False)

--- a/udemy_enroller/udemy.py
+++ b/udemy_enroller/udemy.py
@@ -81,6 +81,13 @@ class UdemyActions:
             response = self.udemy_scraper.get(self.LOGIN_URL)
             soup = BeautifulSoup(response.content, "html.parser")
             csrf_token = soup.find("input", {"name": "csrfmiddlewaretoken"})["value"]
+
+            # Prompt for email/password if we don't have them saved in settings
+            if self.settings.email is None:
+                self.settings.prompt_email()
+            if self.settings.password is None:
+                self.settings.prompt_password()
+
             _form_data = {
                 "email": self.settings.email,
                 "password": self.settings.password,


### PR DESCRIPTION
# Description
Allow input of empty email or password in the settings file
Prompt the user for email/password if the cookie is not set or is expired
Other settings are saved by default (zipcode, languages, categories)

Fixes #260 
## Type of change
- [x] New feature (non-breaking change which adds functionality)
# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

-Updated unittests and dev testing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have added tests that prove my fix is effective or that my feature works (Optional)
- [x] New and existing unit tests pass locally with my changes (Optional)
