### PR TITLE
Fix a bug where we try to access an invalid page from Udemy

### DIFF
--- a/udemy_enroller/udemy_rest.py
+++ b/udemy_enroller/udemy_rest.py
@@ -224,7 +224,7 @@ class UdemyActions:
         my_courses = self.my_courses(page, page_size)
         all_courses.extend(my_courses["results"])
         
-        while ("next" in my_courses and my_courses["next"] != None):
+        while "next" in my_courses and my_courses["next"] is not None:
             page += 1
             my_courses = self.my_courses(page, page_size)
             if "results" in my_courses:

--- a/udemy_enroller/udemy_rest.py
+++ b/udemy_enroller/udemy_rest.py
@@ -220,10 +220,12 @@ class UdemyActions:
         all_courses = list()
         page_size = 100
 
-        my_courses = self.my_courses(1, page_size)
+        page = 1
+        my_courses = self.my_courses(page, page_size)
         all_courses.extend(my_courses["results"])
-        total_pages = my_courses["count"] // page_size
-        for page in range(2, total_pages + 2):
+        
+        while ("next" in my_courses and my_courses["next"] != None):
+            page += 1
             my_courses = self.my_courses(page, page_size)
             if "results" in my_courses:
                 all_courses.extend(my_courses["results"])


### PR DESCRIPTION

For some reason, the for loop is up to total_pages +2 and not total_pages +1. Instead of going this route, I saw that the response contains a "next" key which is None when there is no next page to load, so I replaced the for loop with a while loop which fixed my issue.

# Description
As described in the issue I created earlier, sometimes the code tries to reach a page with my courses that does not exist.
I had a look at the code and for some reason, the for loop is up to total_pages +2 and not total_pages +1.
Instead of going this route, I saw that the response contains a "next" key which is None when there is no next page to load, so I replaced the for loop with a while loop which fixed my issue.

Fixes #405 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I only tested on my machine and I was able to enroll in new courses since.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
