### PR TITLE
Pin `aiohttp` version for Python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ beautifulsoup4 = "^4.11.1"
 cloudscraper = "^1.2.60"
 requests = "^2.27.1"
 webdriver-manager = "^3.7.0"
-aiohttp = {extras = ["speedups"], version = "^3.8.1"}
+aiohttp = {extras = ["speedups"], version = "^3.8.3"}
 price-parser = "^0.3.4"
 
 [tool.poetry.dev-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp[speedups]==3.8.1
+aiohttp[speedups]>=3.8.3
 beautifulsoup4==4.11.1
 ruamel.yaml==0.16.13
 requests==2.27.1

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     ),
     python_requires=">=3.8, <4",
     install_requires=[
-        "aiohttp[speedups]==3.8.1",
+        "aiohttp[speedups]==3.8.3",
         "beautifulsoup4==4.11.1",
         "ruamel.yaml==0.16.13",
         "requests==2.27.1",


### PR DESCRIPTION
# Description

Installation fails on Python 3.11. That is because of https://github.com/aio-libs/aiohttp/issues/6600


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have added tests that prove my fix is effective or that my feature works (Optional)
- [x] New and existing unit tests pass locally with my changes (Optional)


<details>

<summary>Test logs :</summary>

```powershell
PS C:\Users\Asus\Desktop\Automatic-Udemy-Course-Enroller-GET-PAID-UDEMY-COURSES-for-FREE> pipenv run pytest .
======================================================================= test session starts ========================================================================
platform win32 -- Python 3.11.1, pytest-7.2.1, pluggy-1.0.0
rootdir: C:\Users\Asus\Desktop\Automatic-Udemy-Course-Enroller-GET-PAID-UDEMY-COURSES-for-FREE, configfile: pytest.ini
plugins: cov-4.0.0
collected 27 items

tests\core\test_driver_manager.py .........                                                                                                                   [ 33%]
tests\core\test_settings.py .............                                                                                                                     [ 81%]
tests\core\scrapers\test_tutorialbar.py sss..                                                                                                                 [100%]

========================================================================= warnings summary ========================================================================= 
tests\core\scrapers\test_tutorialbar.py:26
  C:\Users\Asus\Desktop\Automatic-Udemy-Course-Enroller-GET-PAID-UDEMY-COURSES-for-FREE\tests\core\scrapers\test_tutorialbar.py:26: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html    
    @pytest.mark.asyncio

tests\core\scrapers\test_tutorialbar.py:65
  C:\Users\Asus\Desktop\Automatic-Udemy-Course-Enroller-GET-PAID-UDEMY-COURSES-for-FREE\tests\core\scrapers\test_tutorialbar.py:65: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html    
    @pytest.mark.asyncio

tests/core/scrapers/test_tutorialbar.py::test_run[List of courses]
tests/core/scrapers/test_tutorialbar.py::test_run[Empty courses]
tests/core/scrapers/test_tutorialbar.py::test_get_course_links
  C:\Users\Asus\.virtualenvs\Automatic-Udemy-Course-Enroller-GET-PAID-U-E1MMInzQ\Lib\site-packages\_pytest\python.py:184: PytestUnhandledCoroutineWarning: async def functions are not natively supported and have been skipped.
  You need to install a suitable plugin for your async framework, for example:
    - anyio
    - pytest-asyncio
    - pytest-tornasync
    - pytest-trio
    - pytest-twisted
    warnings.warn(PytestUnhandledCoroutineWarning(msg.format(nodeid)))

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

---------- coverage: platform win32, python 3.11.1-final-0 -----------
Name                                        Stmts   Miss  Cover   Missing
-------------------------------------------------------------------------
setup.py                                        5      5     0%   1-9
udemy_enroller.py                               3      3     0%   1-4
udemy_enroller\cli.py                          43     43     0%   1-191
udemy_enroller\http.py                         13      9    31%   16-24
udemy_enroller\runner.py                       86     86     0%   1-195
udemy_enroller\scrapers\base_scraper.py        81     40    51%   27, 31, 39-40, 43-44, 47-48, 51-52, 58, 61-64, 69-80, 91-108, 119-123
udemy_enroller\scrapers\coursevania.py         64     44    31%   23-29, 38-43, 51-60, 68-77, 85-117, 127-133, 142
udemy_enroller\scrapers\discudemy.py           47     29    38%   21-25, 34-39, 47-62, 73-78, 87, 102
udemy_enroller\scrapers\freebiesglobal.py      47     29    38%   21-25, 34-39, 47-67, 78-84, 93, 108
udemy_enroller\scrapers\manager.py             22     11    50%   20-32, 45-52, 60
udemy_enroller\scrapers\tutorialbar.py         57     33    42%   25, 36-38, 46-60, 69-76, 85-98, 109-115, 124
udemy_enroller\settings.py                    115     20    83%   34, 36, 105-106, 111, 122-123, 130, 207-215, 223-227, 235, 243
udemy_enroller\udemy_rest.py                  242    173    29%   26-28, 52, 55-65, 109-119, 128-206, 214-227, 236, 245, 254-255, 268-291, 303-311, 323-334, 345, 356, 366, 375-408, 417-421, 439-464, 474, 497-499, 507-515, 523-524
udemy_enroller\udemy_ui.py                    196    152    22%   37, 41-58, 81-85, 95-140, 149-256, 259-269, 272-288, 291-314, 317-350, 358-363
-------------------------------------------------------------------------
TOTAL                                        1111    677    39%

6 files skipped due to complete coverage.
Coverage XML written to file coverage.xml

============================================================ 24 passed, 3 skipped, 5 warnings in 1.71s ============================================================= 
PS C:\Users\Asus\Desktop\Automatic-Udemy-Course-Enroller-GET-PAID-UDEMY-COURSES-for-FREE> 
```

</details> 

