### PR TITLE
Fixed typo, command is now run_enroller

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ Props to Davidd Sargent for making a super simple video tutorial. If you prefer 
 
 3 . Run the script in terminal with your target runner:
 
-- `udemy_enroller`
-- `udemy_enroller --browser=chrome`
-- `udemy_enroller --browser=chromium` 
+- `run_enroller`
+- `run_enroller --browser=chrome`
+- `run_enroller --browser=chromium` 
 
 <br/>
 


### PR DESCRIPTION
Changed the README docs since the file udemy_enroller.py is no longer available and is now run_enroller.py figured out by trial and error when running the script