### PR TITLE
Fixed idownloadcoupon scraping

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 """Setup."""
+
 import pathlib
 
 from setuptools import find_packages, setup

--- a/udemy_enroller/__init__.py
+++ b/udemy_enroller/__init__.py
@@ -1,4 +1,5 @@
 """."""
+
 from .driver_manager import ALL_VALID_BROWSER_STRINGS, DriverManager  # noqa: F401
 from .logger import load_logging_config
 from .scrapers.manager import ScraperManager  # noqa: F401

--- a/udemy_enroller/cli.py
+++ b/udemy_enroller/cli.py
@@ -1,4 +1,5 @@
 """CLI entrypoint for this script."""
+
 import argparse
 import logging
 import platform

--- a/udemy_enroller/driver_manager.py
+++ b/udemy_enroller/driver_manager.py
@@ -1,4 +1,5 @@
 """Webdriver manager."""
+
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options as ChromeOptions
 from webdriver_manager.chrome import ChromeDriverManager

--- a/udemy_enroller/http_utils.py
+++ b/udemy_enroller/http_utils.py
@@ -23,3 +23,21 @@ async def http_get(url, headers=None):
                 return text
     except Exception as e:
         logger.error(f"Error in get request: {e}")
+
+
+async def http_get_no_redirect(url, headers=None):
+    """
+    Send REST get request to the url passed in but doesn't follow redirect.
+
+    :param url: The Url to get call get request on
+    :param headers: The headers to pass with the get request
+    :return: data if any exists
+    """
+    if headers is None:
+        headers = {}
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, headers=headers, allow_redirects=False) as response:
+                return response
+    except Exception as e:
+        logger.error(f"Error in get request: {e}")

--- a/udemy_enroller/http_utils.py
+++ b/udemy_enroller/http_utils.py
@@ -1,4 +1,5 @@
 """HTTP helpers."""
+
 import aiohttp
 
 from udemy_enroller.logger import get_logger
@@ -37,7 +38,9 @@ async def http_get_no_redirect(url, headers=None):
         headers = {}
     try:
         async with aiohttp.ClientSession() as session:
-            async with session.get(url, headers=headers, allow_redirects=False) as response:
+            async with session.get(
+                url, headers=headers, allow_redirects=False
+            ) as response:
                 return response
     except Exception as e:
         logger.error(f"Error in get request: {e}")

--- a/udemy_enroller/logger.py
+++ b/udemy_enroller/logger.py
@@ -1,4 +1,5 @@
 """Logger utilities."""
+
 import logging
 import logging.config
 import os

--- a/udemy_enroller/runner.py
+++ b/udemy_enroller/runner.py
@@ -1,4 +1,5 @@
 """Runner."""
+
 import asyncio
 import random
 import time

--- a/udemy_enroller/scrapers/base_scraper.py
+++ b/udemy_enroller/scrapers/base_scraper.py
@@ -1,4 +1,5 @@
 """Base Scraper."""
+
 import datetime
 import logging
 import re

--- a/udemy_enroller/scrapers/coursevania.py
+++ b/udemy_enroller/scrapers/coursevania.py
@@ -1,4 +1,5 @@
 """Coursevania Scraper."""
+
 import asyncio
 import json
 from typing import List

--- a/udemy_enroller/scrapers/discudemy.py
+++ b/udemy_enroller/scrapers/discudemy.py
@@ -1,4 +1,5 @@
 """Discudemy scraper."""
+
 import asyncio
 from typing import List
 

--- a/udemy_enroller/scrapers/freebiesglobal.py
+++ b/udemy_enroller/scrapers/freebiesglobal.py
@@ -1,4 +1,5 @@
 """Freebiesglobal Scraper."""
+
 import asyncio
 from typing import List
 

--- a/udemy_enroller/scrapers/idownloadcoupon.py
+++ b/udemy_enroller/scrapers/idownloadcoupon.py
@@ -1,4 +1,5 @@
-"""IDownloadCoupon scraper.""" 
+"""IDownloadCoupon scraper."""
+
 import asyncio
 import urllib.parse
 from typing import List
@@ -93,7 +94,6 @@ class IDownloadCouponScraper(BaseScraper):
         if urls and link.startswith("https://click.linksynergy.com"):
             return cls.validate_coupon_url(urllib.parse.unquote(urls[1]))
 
-
     async def gather_udemy_course_links(self, courses: List[str]):
         """
         Async fetching of the udemy course links.
@@ -102,5 +102,7 @@ class IDownloadCouponScraper(BaseScraper):
         :return: list of udemy links
         """
         return [
-            link for link in await asyncio.gather(*map(self.get_udemy_course_link, courses)) if link is not None
+            link
+            for link in await asyncio.gather(*map(self.get_udemy_course_link, courses))
+            if link is not None
         ]

--- a/udemy_enroller/scrapers/manager.py
+++ b/udemy_enroller/scrapers/manager.py
@@ -1,4 +1,5 @@
 """Manager for scapers."""
+
 import asyncio
 import typing
 from functools import reduce

--- a/udemy_enroller/scrapers/tutorialbar.py
+++ b/udemy_enroller/scrapers/tutorialbar.py
@@ -1,4 +1,5 @@
 """Tutorialbar scraper."""
+
 import asyncio
 from typing import List
 

--- a/udemy_enroller/settings.py
+++ b/udemy_enroller/settings.py
@@ -1,4 +1,5 @@
 """Settings."""
+
 import getpass
 import os.path
 from distutils.util import strtobool

--- a/udemy_enroller/udemy_rest.py
+++ b/udemy_enroller/udemy_rest.py
@@ -1,4 +1,5 @@
 """Udemy REST."""
+
 import json
 import os
 import re

--- a/udemy_enroller/udemy_ui.py
+++ b/udemy_enroller/udemy_ui.py
@@ -1,4 +1,5 @@
 """Udemy UI."""
+
 import time
 from dataclasses import dataclass, field
 from datetime import datetime

--- a/udemy_enroller/utils.py
+++ b/udemy_enroller/utils.py
@@ -1,4 +1,5 @@
 """Utility functions."""
+
 import os
 
 


### PR DESCRIPTION
# Description

Fixed idownloadcoupon scraping by redirecting redeem button url manually and parsing the redirected udemy link with the coupon code.

Fixes #432 

## Type of change
Added a new function in http_utils.py called http_get_no_redirect that doesn't follow redirected url
Modified idownloadcoupon.py file and function called get_udemy_course_link. changed the url parsing code.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Running the script in idownloadcoupon only mode by running `python.exe run_enroller.py --idownloadcoupon`

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have added tests that prove my fix is effective or that my feature works (Optional)
- [ ] New and existing unit tests pass locally with my changes (Optional)
