### PR TITLE
Robust HTTP Contract, Scraper Hardening, Fuzz Observability, RunConfig, and UI Login Improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        python-version: ["3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install project
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install -r requirements-dev.txt
+      - name: Run unit tests
+        run: |
+          pytest -q
+      - name: CLI help
+        run: |
+          python -m udemy_enroller.cli --help

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 # Created by .ignore support plugin (hsz.mobi)
+code-analysis.json
+code-implementations.json
+code-implementations-technical.json
+code-diff-analysis.json
+code-architecture-explained.json
 ### JetBrains template
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -1,0 +1,17 @@
+Ambientes
+
+Desenvolvimento
+- `.\scripts\setup.ps1` para preparar venv
+- Execução local com `scripts/run-ui.ps1` ou `scripts/run-rest.ps1`
+
+Teste
+- `pytest` (Windows: `.\scripts\test.ps1`)
+- Métricas fuzz: ver `fuzz_summary` em logs
+
+Produção
+- Instalação via `pip install .` ou artefato `wheel` (ver `scripts/build.ps1`)
+- Use REST por padrão; UI requer navegador instalado
+
+Variáveis de Ambiente
+- `UDEMY_EMAIL`, `UDEMY_PASSWORD`: login automatizado em CI
+- `CI_TEST`: se `True`, fluxo CI com encerramento precoce após tentativa

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,25 @@
+Requisitos
+- Python 3.9–3.12
+- Windows PowerShell (ou Bash em Linux/macOS)
+
+Instalação (Windows)
+1. Abra PowerShell no diretório do projeto
+2. Crie/ative venv e instale dependências:
+   - `.\scripts\setup.ps1`
+3. (Opcional) Instale ferramentas de dev:
+   - `pip install -r requirements-dev.txt`
+
+Instalação (Linux/macOS)
+1. `python3 -m venv .venv`
+2. `source .venv/bin/activate`
+3. `pip install -e .`
+4. (Opcional) `pip install -r requirements-dev.txt`
+
+Build do pacote
+- Windows: `.\scripts\build.ps1`
+- Linux/macOS: `python -m build`
+
+Resolução de problemas
+- Se `udemy_enroller` não for reconhecido, use `python -m udemy_enroller.cli`
+- Se o Chrome não abrir, verifique instalação local do navegador
+- Logs: `~/.udemy_enroller/app.log`

--- a/docs/TECH_CHANGES.md
+++ b/docs/TECH_CHANGES.md
@@ -1,0 +1,83 @@
+# Technical Changes and Implementation Notes
+
+## Overview
+- Introduced explicit HTTP contract, hardened scraper pipeline, improved concurrency and observability, stabilized runner/CLI, and added dev automation. Validated REST execution end-to-end with enrollment and statistics.
+
+## HTTP Contract
+- Added `Result[T,E]` and `HttpRequestFailed` with `retryable`.
+- `http_get(url, headers=None, timeout=15) -> Result[bytes, HttpRequestFailed]`.
+- Retryable rules: timeouts/5xx → true; 403/404 → false; other 4xx → false.
+- References: `udemy_enroller/types.py:1`, `udemy_enroller/http_utils.py:9`.
+
+## Scraper Updates
+- All scrapers now consume `Result` and gate parsing on `res.ok`.
+- References:
+  - `udemy_enroller/scrapers/tutorialbar.py:85,101`
+  - `udemy_enroller/scrapers/discudemy.py:49,72`
+  - `udemy_enroller/scrapers/freebiesglobal.py:49,77`
+  - `udemy_enroller/scrapers/idownloadcoupon.py:68`
+  - `udemy_enroller/scrapers/coursevania.py:69,104,127`
+
+## Concurrency & Fuzz
+- `FuzzManager` enforces `HARD_MAX_CONCURRENCY=20` clamp with warning.
+- Aggregated counters: total/success/error/timeout and total `duration`.
+- Single-line summary `fuzz_summary total=... duration=...s urls=...`.
+- References: `udemy_enroller/scrapers/fuzz_manager.py:12,40`.
+
+## Runner & CLI Stabilization
+- `RunConfig` dataclass introduced for stable API across CLI/Runner.
+- CLI accepts `--email` and `--password`, setting env before `Settings`.
+- Runner initializes `asyncio` event loop if missing (Python 3.12+).
+- UI runner falls back to REST on failure, ensures browser quit.
+- References: `udemy_enroller/run_config.py:1`, `udemy_enroller/cli.py:240`, `udemy_enroller/runner.py:36,145,250`.
+
+## Settings & Credentials
+- Removed `distutils`; implemented `_strtobool` compatible with 3.12+.
+- Credential collection:
+  - Use `UDEMY_EMAIL`/`UDEMY_PASSWORD` if set.
+  - Fallback to `getpass`; on failure, non-hidden `input`.
+- References: `udemy_enroller/settings.py:32,97,119`.
+
+## UI Login Hardening
+- Attempt cookie-based login (inject `access_token/client_id/csrftoken`).
+- Fallback to interactive login:
+  - Multiple selectors and iframe traversal for email/password fields.
+  - Submit via `auth-submit-button` or `//button[@type='submit']`.
+- References: `udemy_enroller/udemy_ui.py:97,100,114`.
+
+## Developer Experience
+- Scripts (PowerShell):
+  - `scripts/setup.ps1`: venv + install + dev deps
+  - `scripts/run-ui.ps1`: activates venv and runs UI
+  - `scripts/run-rest.ps1`: activates venv and runs REST
+  - `scripts/test.ps1`: ensures dev deps then runs `pytest`
+  - `scripts/build.ps1`: build artifacts
+- CI Workflow:
+  - `.github/workflows/ci.yml`: Windows/Ubuntu/macOS with Python 3.12
+
+## Tests Added
+- BaseScraper `time_run` marks COMPLETE on exceptions.
+- FuzzManager clamp and run path produce at least one URL and clamp active.
+- References: `tests/test_base_scraper_time_run.py:1`, `tests/test_fuzz_manager.py:1`.
+
+## Observability & Logging
+- Debug mode raises stream and file handlers to DEBUG.
+- `fuzz_summary` logs single-line execution metrics.
+- `RunStatistics.table` emits consolidated stats.
+- References: `udemy_enroller/logger.py:17`, `udemy_enroller/scrapers/fuzz_manager.py:40`, `udemy_enroller/udemy_rest.py:58`.
+
+## Security & Safety
+- No secrets printed; credentials via env/flags; cookies persisted to app dir.
+- HTTP `retryable` enables safer backoff decisions in future work.
+
+## Usage Summary
+- REST:
+  - `python run_enroller.py --debug --email <EMAIL> --password <PASSWORD>`
+- UI with REST fallback:
+  - `python run_enroller.py --browser chrome --debug --email <EMAIL> --password <PASSWORD>`
+- Scripts:
+  - `.\scripts\setup.ps1`, `.\scripts\run-ui.ps1 -Browser chrome -Debug`, `.\scripts\run-rest.ps1 -Debug`.
+
+## Validation Outcome
+- Verified REST flow end-to-end with successful enrollment and stats.
+- UI remains guarded by site anti-automation; runner falls back to REST automatically and completes.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,22 @@
+Modos de execução
+- REST (sem navegador):
+  - `udemy_enroller`
+  - `python -m udemy_enroller.cli`
+- UI (com navegador via Selenium):
+  - `udemy_enroller --browser chrome`
+  - `python -m udemy_enroller.cli --browser chrome`
+
+Flags principais
+- `--idownloadcoupon --freebiesglobal --tutorialbar --discudemy --coursevania`
+- `--max-pages N`
+- `--experimental-fuzz --fuzz-seed 123 --max-concurrency 10`
+- `--delete-settings --delete-cookie`
+- `--debug`
+
+Ambiente CI/headless
+- Defina `UDEMY_EMAIL` e `UDEMY_PASSWORD`
+- UI headless: `--browser chrome` e `CI_TEST=True`
+
+Logs
+- Em tempo real no terminal (stream)
+- Arquivo: `~/.udemy_enroller/app.log`

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,9 @@
+build
+pip-tools
+pytest
+pytest-cov
+pytest-asyncio
+pip-audit
+safety
+black
+isort

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,0 +1,8 @@
+Param(
+  [string]$VenvPath = ".venv"
+)
+
+if (Test-Path $VenvPath) { . (Join-Path $VenvPath "Scripts/Activate.ps1") }
+
+pip install build
+python -m build

--- a/scripts/run-rest.ps1
+++ b/scripts/run-rest.ps1
@@ -1,0 +1,15 @@
+Param(
+  [switch]$Debug,
+  [string]$VenvPath = ".venv"
+)
+
+if (-Not (Test-Path $VenvPath)) {
+  . (Join-Path "scripts" "setup.ps1")
+} else {
+  . (Join-Path $VenvPath "Scripts/Activate.ps1")
+}
+
+$argsList = @("-m", "udemy_enroller.cli")
+if ($Debug) { $argsList += "--debug" }
+
+python @argsList

--- a/scripts/run-ui.ps1
+++ b/scripts/run-ui.ps1
@@ -1,0 +1,16 @@
+Param(
+  [string]$Browser = "chrome",
+  [switch]$Debug,
+  [string]$VenvPath = ".venv"
+)
+
+if (-Not (Test-Path $VenvPath)) {
+  . (Join-Path "scripts" "setup.ps1")
+} else {
+  . (Join-Path $VenvPath "Scripts/Activate.ps1")
+}
+
+$argsList = @("-m", "udemy_enroller.cli", "--browser", $Browser)
+if ($Debug) { $argsList += "--debug" }
+
+python @argsList

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -1,0 +1,20 @@
+Param(
+    [string]$PythonExe = "python",
+    [string]$VenvPath = ".venv"
+)
+
+if (-Not (Test-Path $VenvPath)) {
+  & $PythonExe -m venv $VenvPath
+}
+
+$env:VIRTUAL_ENV = (Resolve-Path $VenvPath).Path
+$activate = Join-Path $VenvPath "Scripts/Activate.ps1"
+. $activate
+
+pip install --upgrade pip
+pip install -e .
+if (Test-Path "requirements-dev.txt") {
+  pip install -r requirements-dev.txt
+}
+
+Write-Host "Environment ready. To activate later: .\$VenvPath\Scripts\Activate.ps1"

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -1,0 +1,15 @@
+Param(
+  [string]$VenvPath = ".venv"
+)
+
+if (-Not (Test-Path $VenvPath)) {
+  . (Join-Path "scripts" "setup.ps1")
+} else {
+  . (Join-Path $VenvPath "Scripts/Activate.ps1")
+}
+
+if (Test-Path "requirements-dev.txt") {
+  pip install -r requirements-dev.txt
+}
+
+pytest -q

--- a/tests/test_base_scraper_time_run.py
+++ b/tests/test_base_scraper_time_run.py
@@ -1,0 +1,28 @@
+import asyncio
+import pytest
+
+from udemy_enroller.scrapers.base_scraper import BaseScraper, ScraperStates
+
+
+class FailingScraper(BaseScraper):
+    DOMAIN = "http://example.com"
+
+    async def run(self):
+        return await self.get_links()
+
+    async def get_links(self):
+        raise RuntimeError("boom")
+
+
+@pytest.mark.asyncio
+async def test_time_run_marks_complete_on_exception():
+    s = FailingScraper()
+    s.scraper_name = "failing"
+
+    @BaseScraper.time_run
+    async def wrapped(self):
+        return await self.get_links()
+
+    res = await wrapped(s)
+    assert res == []
+    assert s.state == ScraperStates.COMPLETE.value

--- a/tests/test_fuzz_manager.py
+++ b/tests/test_fuzz_manager.py
@@ -1,0 +1,32 @@
+import asyncio
+import pytest
+
+from udemy_enroller.scrapers.fuzz_manager import FuzzManager, HARD_MAX_CONCURRENCY
+from udemy_enroller.scrapers.base_scraper import BaseScraper
+
+
+class DummyScraper(BaseScraper):
+    DOMAIN = "http://example.com"
+
+    def __init__(self, enabled=True):
+        super().__init__()
+        self.scraper_name = "dummy"
+        if not enabled:
+            self.set_state_disabled()
+
+    async def run(self):
+        return await self.get_links()
+
+    async def get_links(self):
+        return ["https://www.udemy.com/course/test/?couponCode=FREE"]
+
+
+@pytest.mark.asyncio
+async def test_fuzz_manager_clamp_and_run():
+    fm = FuzzManager(True, False, False, False, False, max_pages=1, fuzz_enabled=False, max_concurrency=500)
+    # monkey-patch enabled scrapers to only our dummy
+    fm._scrapers = [DummyScraper(enabled=True)]
+    res = await fm.run()
+    assert isinstance(res, list) and len(res) == 1
+    # semaphore should be clamped
+    assert fm.semaphore._value <= HARD_MAX_CONCURRENCY

--- a/udemy_enroller/__init__.py
+++ b/udemy_enroller/__init__.py
@@ -2,6 +2,7 @@
 from .driver_manager import ALL_VALID_BROWSER_STRINGS, DriverManager  # noqa: F401
 from .logger import load_logging_config
 from .scrapers.manager import ScraperManager  # noqa: F401
+from .scrapers.fuzz_manager import FuzzManager  # noqa: F401
 from .settings import Settings  # noqa: F401
 from .udemy_rest import UdemyActions, UdemyStatus  # noqa: F401
 from .udemy_ui import UdemyActionsUI  # noqa: F401

--- a/udemy_enroller/cli.py
+++ b/udemy_enroller/cli.py
@@ -6,11 +6,12 @@ import sys
 from argparse import Namespace
 from typing import Tuple, Union
 
-from pkg_resources import DistributionNotFound, get_distribution
+import importlib.metadata as im
 
 from udemy_enroller import ALL_VALID_BROWSER_STRINGS, DriverManager, Settings
 from udemy_enroller.logger import get_logger
-from udemy_enroller.runner import redeem_courses, redeem_courses_ui
+from udemy_enroller.runner import redeem_courses, redeem_courses_ui, redeem_courses_config, redeem_courses_ui_config
+from udemy_enroller.run_config import RunConfig
 
 logger = get_logger()
 
@@ -34,12 +35,11 @@ def log_package_details() -> None:
     :return: None
     """
     try:
-        distribution = get_distribution("udemy_enroller")
-        if distribution:
-            logger.debug(f"Name: {distribution.project_name}")
-            logger.debug(f"Version: {distribution.version}")
-            logger.debug(f"Location: {distribution.location}")
-    except DistributionNotFound:
+        name = "udemy_enroller"
+        version = im.version(name)
+        logger.debug(f"Name: {name}")
+        logger.debug(f"Version: {version}")
+    except im.PackageNotFoundError:
         logger.debug("Not installed on python env.")
 
 
@@ -106,6 +106,9 @@ def run(
     discudemy_enabled: bool,
     coursevania_enabled: bool,
     max_pages: Union[int, None],
+    experimental_fuzz: bool,
+    fuzz_seed: Union[int, None],
+    max_concurrency: int,
     delete_settings: bool,
     delete_cookie: bool,
 ):
@@ -124,28 +127,25 @@ def run(
     :return:
     """
     settings = Settings(delete_settings, delete_cookie)
+    config = RunConfig(
+        browser,
+        idownloadcoupon_enabled,
+        freebiesglobal_enabled,
+        tutorialbar_enabled,
+        discudemy_enabled,
+        coursevania_enabled,
+        max_pages,
+        delete_settings,
+        delete_cookie,
+        experimental_fuzz,
+        fuzz_seed,
+        max_concurrency,
+    )
     if browser:
         dm = DriverManager(browser=browser, is_ci_build=settings.is_ci_build)
-        redeem_courses_ui(
-            dm.driver,
-            settings,
-            idownloadcoupon_enabled,
-            freebiesglobal_enabled,
-            tutorialbar_enabled,
-            discudemy_enabled,
-            coursevania_enabled,
-            max_pages,
-        )
+        redeem_courses_ui_config(dm.driver, settings, config)
     else:
-        redeem_courses(
-            settings,
-            idownloadcoupon_enabled,
-            freebiesglobal_enabled,
-            tutorialbar_enabled,
-            discudemy_enabled,
-            coursevania_enabled,
-            max_pages,
-        )
+        redeem_courses_config(settings, config)
 
 
 def parse_args() -> Namespace:
@@ -200,6 +200,24 @@ def parse_args() -> Namespace:
         help="Max pages to scrape from sites (if pagination exists) (Default is 5)",
     )
     parser.add_argument(
+        "--experimental-fuzz",
+        action="store_true",
+        default=False,
+        help="Enable experimental fuzz mode for scrapers",
+    )
+    parser.add_argument(
+        "--fuzz-seed",
+        type=int,
+        required=False,
+        help="Seed for experimental fuzz mode",
+    )
+    parser.add_argument(
+        "--max-concurrency",
+        type=int,
+        default=10,
+        help="Max concurrent scraper tasks (Default is 10)",
+    )
+    parser.add_argument(
         "--delete-settings",
         action="store_true",
         default=False,
@@ -217,6 +235,19 @@ def parse_args() -> Namespace:
         "--debug",
         action="store_true",
         help="Enable debug logging",
+    )
+
+    parser.add_argument(
+        "--email",
+        type=str,
+        required=False,
+        help="Udemy email (overrides settings/env if provided)",
+    )
+    parser.add_argument(
+        "--password",
+        type=str,
+        required=False,
+        help="Udemy password (overrides settings/env if provided)",
     )
 
     return parser.parse_args()
@@ -244,6 +275,13 @@ def main():
             args.discudemy,
             args.coursevania,
         )
+        # Allow passing credentials via CLI flags without changing Settings API
+        if args.email:
+            import os
+            os.environ["UDEMY_EMAIL"] = args.email
+        if args.password:
+            import os
+            os.environ["UDEMY_PASSWORD"] = args.password
         run(
             args.browser,
             idownloadcoupon_enabled,
@@ -252,6 +290,9 @@ def main():
             discudemy_enabled,
             coursevania_enabled,
             args.max_pages,
+            args.experimental_fuzz,
+            args.fuzz_seed,
+            args.max_concurrency,
             args.delete_settings,
             args.delete_cookie,
         )

--- a/udemy_enroller/http_utils.py
+++ b/udemy_enroller/http_utils.py
@@ -1,12 +1,13 @@
 """HTTP helpers."""
 import aiohttp
+from udemy_enroller.types import HttpRequestFailed, Result
 
 from udemy_enroller.logger import get_logger
 
 logger = get_logger()
 
 
-async def http_get(url, headers=None):
+async def http_get(url, headers=None, timeout: int = 15) -> Result[bytes, HttpRequestFailed]:
     """
     Send REST get request to the url passed in.
 
@@ -17,9 +18,19 @@ async def http_get(url, headers=None):
     if headers is None:
         headers = {}
     try:
-        async with aiohttp.ClientSession() as session:
+        client_timeout = aiohttp.ClientTimeout(total=timeout)
+        async with aiohttp.ClientSession(timeout=client_timeout) as session:
             async with session.get(url, headers=headers) as response:
+                if response.status >= 400:
+                    retryable = 500 <= response.status < 600
+                    if response.status in (403, 404):
+                        retryable = False
+                    err = HttpRequestFailed(url=url, status=response.status, reason=response.reason, retryable=retryable)
+                    logger.error(f"GET {url} failed with status {response.status}")
+                    return Result(ok=False, error=err)
                 text = await response.read()
-                return text
+                return Result(ok=True, value=text)
     except Exception as e:
+        err = HttpRequestFailed(url=url, status=None, reason=str(e), retryable=True)
         logger.error(f"Error in get request: {e}")
+        return Result(ok=False, error=err)

--- a/udemy_enroller/run_config.py
+++ b/udemy_enroller/run_config.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class RunConfig:
+    browser: Optional[str]
+    idownloadcoupon_enabled: bool
+    freebiesglobal_enabled: bool
+    tutorialbar_enabled: bool
+    discudemy_enabled: bool
+    coursevania_enabled: bool
+    max_pages: Optional[int]
+    delete_settings: bool
+    delete_cookie: bool
+    experimental_fuzz: bool
+    fuzz_seed: Optional[int]
+    max_concurrency: int

--- a/udemy_enroller/scrapers/base_scraper.py
+++ b/udemy_enroller/scrapers/base_scraper.py
@@ -92,7 +92,7 @@ class BaseScraper(ABC):
                 logger.exception(
                     f"Error while running {self.scraper_name} scraper: {e}"
                 )
-                self.is_complete()
+                self.set_state_complete()
                 return []
             end_time = datetime.datetime.utcnow()
             logger.info(

--- a/udemy_enroller/scrapers/coursevania.py
+++ b/udemy_enroller/scrapers/coursevania.py
@@ -66,9 +66,9 @@ class CoursevaniaScraper(BaseScraper):
         :return: None
         """
         if self._nonce is None:
-            response = await http_get(f"{self.DOMAIN}/courses")
-            if response is not None:
-                soup = BeautifulSoup(response, "html.parser")
+            res = await http_get(f"{self.DOMAIN}/courses")
+            if res.ok and res.value is not None:
+                soup = BeautifulSoup(res.value, "html.parser")
                 for script_element in soup.find_all("script"):
                     if "var stm_lms_nonces" in str(script_element):
                         data = json.loads(
@@ -102,11 +102,9 @@ class CoursevaniaScraper(BaseScraper):
             "TE": "Trailers",
         }
         query_string = urlencode(query_params)
-        response = await http_get(
-            f"{self.DOMAIN}/wp-admin/admin-ajax.php?{query_string}", headers=headers
-        )
-        if response is not None:
-            json_data = json.loads(response)
+        res = await http_get(f"{self.DOMAIN}/wp-admin/admin-ajax.php?{query_string}", headers=headers)
+        if res.ok and res.value is not None:
+            json_data = json.loads(res.value)
             coupons_data = json_data.get("content")
             soup = BeautifulSoup(coupons_data, "html.parser")
             links = soup.find_all("a", class_="heading_font")
@@ -124,9 +122,9 @@ class CoursevaniaScraper(BaseScraper):
         :param str url: The url to scrape data from
         :return: Coupon link of the udemy course
         """
-        text = await http_get(url)
-        if text is not None:
-            soup = BeautifulSoup(text.decode("utf-8"), "html.parser")
+        res = await http_get(url)
+        if res.ok and res.value is not None:
+            soup = BeautifulSoup(res.value.decode("utf-8"), "html.parser")
             udemy_link = (
                 soup.find("div", class_="stm-lms-buy-buttons").find("a").get("href")
             )

--- a/udemy_enroller/scrapers/discudemy.py
+++ b/udemy_enroller/scrapers/discudemy.py
@@ -46,8 +46,10 @@ class DiscUdemyScraper(BaseScraper):
         """
         discudemy_links = []
         self.current_page += 1
-        coupons_data = await http_get(f"{self.DOMAIN}/all/{self.current_page}")
-        soup = BeautifulSoup(coupons_data.decode("utf-8"), "html.parser")
+        res = await http_get(f"{self.DOMAIN}/all/{self.current_page}")
+        if not res.ok or res.value is None:
+            return []
+        soup = BeautifulSoup(res.value.decode("utf-8"), "html.parser")
         for course_card in soup.find_all("a", class_="card-header"):
             url_end = course_card["href"].split("/")[-1]
             discudemy_links.append(f"{self.DOMAIN}/go/{url_end}")
@@ -69,8 +71,10 @@ class DiscUdemyScraper(BaseScraper):
         :param str url: The url to scrape data from
         :return: Coupon link of the udemy course
         """
-        data = await http_get(url)
-        soup = BeautifulSoup(data.decode("utf-8"), "html.parser")
+        res = await http_get(url)
+        if not res.ok or res.value is None:
+            return None
+        soup = BeautifulSoup(res.value.decode("utf-8"), "html.parser")
         for link in soup.find_all("a", href=True):
             udemy_link = cls.validate_coupon_url(link["href"])
             if udemy_link is not None:

--- a/udemy_enroller/scrapers/freebiesglobal.py
+++ b/udemy_enroller/scrapers/freebiesglobal.py
@@ -46,10 +46,10 @@ class FreebiesglobalScraper(BaseScraper):
         """
         freebiesglobal_links = []
         self.current_page += 1
-        coupons_data = await http_get(
-            f"{self.DOMAIN}/dealstore/udemy/page/{self.current_page}"
-        )
-        soup = BeautifulSoup(coupons_data.decode("utf-8"), "html.parser")
+        res = await http_get(f"{self.DOMAIN}/dealstore/udemy/page/{self.current_page}")
+        if not res.ok or res.value is None:
+            return []
+        soup = BeautifulSoup(res.value.decode("utf-8"), "html.parser")
 
         for course_card in soup.find_all(
             "a", class_="img-centered-flex rh-flex-center-align rh-flex-justify-center"
@@ -74,8 +74,10 @@ class FreebiesglobalScraper(BaseScraper):
         :param str url: The url to scrape data from
         :return: Coupon link of the udemy course
         """
-        data = await http_get(url)
-        soup = BeautifulSoup(data.decode("utf-8"), "html.parser")
+        res = await http_get(url)
+        if not res.ok or res.value is None:
+            return None
+        soup = BeautifulSoup(res.value.decode("utf-8"), "html.parser")
         for link in soup.find_all("a", class_="re_track_btn"):
             udemy_link = cls.validate_coupon_url(link["href"])
 

--- a/udemy_enroller/scrapers/fuzz_manager.py
+++ b/udemy_enroller/scrapers/fuzz_manager.py
@@ -1,0 +1,83 @@
+import asyncio
+import random
+from typing import List, Optional
+
+from udemy_enroller.logger import get_logger
+from udemy_enroller.scrapers.manager import ScraperManager
+
+
+logger = get_logger()
+
+
+HARD_MAX_CONCURRENCY = 20
+
+
+class FuzzManager(ScraperManager):
+    def __init__(
+        self,
+        idownloadcoupon_enabled: bool,
+        freebiesglobal_enabled: bool,
+        tutorialbar_enabled: bool,
+        discudemy_enabled: bool,
+        coursevania_enabled: bool,
+        max_pages: Optional[int],
+        fuzz_enabled: bool = False,
+        fuzz_seed: Optional[int] = None,
+        max_concurrency: int = 10,
+        task_timeout: int = 30,
+    ):
+        super().__init__(
+            idownloadcoupon_enabled,
+            freebiesglobal_enabled,
+            tutorialbar_enabled,
+            discudemy_enabled,
+            coursevania_enabled,
+            max_pages,
+        )
+        self.fuzz_enabled = fuzz_enabled
+        self.fuzz_seed = fuzz_seed
+        if max_concurrency > HARD_MAX_CONCURRENCY:
+            logger.warning(f"max_concurrency clamped from {max_concurrency} to {HARD_MAX_CONCURRENCY}")
+        self.semaphore = asyncio.Semaphore(max(1, min(max_concurrency, HARD_MAX_CONCURRENCY)))
+        self.task_timeout = task_timeout
+        self._rand = random.Random(fuzz_seed) if fuzz_seed is not None else random
+
+    async def run(self) -> List[str]:
+        urls: List[str] = []
+        total = 0
+        success = 0
+        errors = 0
+        timeouts = 0
+        import time
+        start = time.monotonic()
+        enabled_scrapers = self._enabled_scrapers()
+        tasks = [self._scrape(scraper) for scraper in enabled_scrapers]
+        if tasks:
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for res in results:
+                total += 1
+                if isinstance(res, Exception):
+                    if isinstance(res, asyncio.TimeoutError):
+                        timeouts += 1
+                    else:
+                        errors += 1
+                    logger.error(res)
+                else:
+                    success += 1
+                    urls.extend(res)
+        if self.fuzz_enabled and urls:
+            self._rand.shuffle(urls)
+        duration = time.monotonic() - start
+        logger.info(
+            f"fuzz_summary total={total} success={success} error={errors} timeout={timeouts} duration={duration:.2f}s urls={len(urls)}"
+        )
+        return urls
+
+    async def _scrape(self, scraper) -> List[str]:
+        async with self.semaphore:
+            if self.fuzz_enabled:
+                jitter = self._rand.uniform(0, 0.25)
+                await asyncio.sleep(jitter)
+                if self.max_pages is not None:
+                    scraper.max_pages = max(1, min(self.max_pages, scraper.max_pages or self.max_pages))
+            return await asyncio.wait_for(scraper.run(), timeout=self.task_timeout)

--- a/udemy_enroller/scrapers/idownloadcoupon.py
+++ b/udemy_enroller/scrapers/idownloadcoupon.py
@@ -65,9 +65,9 @@ class IDownloadCouponScraper(BaseScraper):
         :param str url: The url to scrape data from
         :return: list of pages that contain Udemy coupons
         """
-        text = await http_get(url)
-        if text is not None:
-            soup = BeautifulSoup(text.decode("utf-8"), "html.parser")
+        res = await http_get(url)
+        if res.ok and res.value is not None:
+            soup = BeautifulSoup(res.value.decode("utf-8"), "html.parser")
 
             links = soup.find_all("li", class_="product")
             course_links = [link.find_all("a")[1].get("href") for link in links]

--- a/udemy_enroller/scrapers/tutorialbar.py
+++ b/udemy_enroller/scrapers/tutorialbar.py
@@ -82,9 +82,9 @@ class TutorialBarScraper(BaseScraper):
         :param str url: The url to scrape data from
         :return: list of pages on tutorialbar.com that contain Udemy coupons
         """
-        text = await http_get(url)
-        if text is not None:
-            soup = BeautifulSoup(text.decode("utf-8"), "html.parser")
+        result = await http_get(url)
+        if result.ok and result.value is not None:
+            soup = BeautifulSoup(result.value.decode("utf-8"), "html.parser")
 
             links = soup.find_all("h3")
             course_links = [link.find("a").get("href") for link in links]
@@ -105,9 +105,9 @@ class TutorialBarScraper(BaseScraper):
         :param str url: The url to scrape data from
         :return: Coupon link of the udemy course
         """
-        text = await http_get(url)
-        if text is not None:
-            soup = BeautifulSoup(text.decode("utf-8"), "html.parser")
+        result = await http_get(url)
+        if result.ok and result.value is not None:
+            soup = BeautifulSoup(result.value.decode("utf-8"), "html.parser")
             udemy_link = (
                 soup.find("span", class_="rh_button_wrapper").find("a").get("href")
             )

--- a/udemy_enroller/types.py
+++ b/udemy_enroller/types.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+from typing import Generic, Optional, TypeVar
+
+
+T = TypeVar("T")
+E = TypeVar("E")
+
+
+class HttpRequestFailed(Exception):
+    def __init__(self, url: str, status: Optional[int] = None, reason: Optional[str] = None, retryable: bool = False):
+        self.url = url
+        self.status = status
+        self.reason = reason
+        self.retryable = retryable
+        super().__init__(f"HTTP request failed: {status} {reason} @ {url} (retryable={retryable})")
+
+
+@dataclass
+class Result(Generic[T, E]):
+    ok: bool
+    value: Optional[T] = None
+    error: Optional[E] = None

--- a/udemy_enroller/udemy_rest.py
+++ b/udemy_enroller/udemy_rest.py
@@ -504,8 +504,10 @@ class UdemyActions:
         :return:
         """
         logger.info("Caching cookie for future use")
-        with open(self._cookie_file, "a+") as f:
+        tmp_path = f"{self._cookie_file}.tmp"
+        with open(tmp_path, "w") as f:
             f.write(json.dumps(cookies))
+        os.replace(tmp_path, self._cookie_file)
 
     def _load_cookies(self) -> Dict:
         """
@@ -530,4 +532,5 @@ class UdemyActions:
         :return:
         """
         logger.info("Deleting cookie")
-        os.remove(self._cookie_file)
+        if os.path.isfile(self._cookie_file):
+            os.remove(self._cookie_file)


### PR DESCRIPTION
# Description
This PR introduces reliability, observability, and usability improvements across the project:

- Explicit HTTP contract using Result[bytes, HttpRequestFailed] with retryable semantics to remove None ambiguity and enable safer error handling.
- Scraper refactors to consume the new HTTP Result contract, hardening parsing and last-page handling across sources.
- New FuzzManager that clamps concurrency ( HARD_MAX_CONCURRENCY=20 ), adds jitter and timeouts, and emits a single-line summary with total duration, counts, and outcomes.
- Stable execution API via RunConfig and CLI enhancements: --email and --password flags for non-interactive runs.
- Runner fix for Python 3.12+ ensuring asyncio loop initialization when no loop exists.
- UI login hardening: cookie injection from REST, multi-selector lookup, iframe traversal, and fallback submit ; automatic REST fallback when UI is blocked by anti-automation.
- Atomic cookie writes and safe deletion in REST.
- Developer experience: PowerShell scripts for setup/run/test/build and multi-OS CI workflow; documentation updates.
- .gitignore updated to exclude generated analysis JSONs.
Dependencies:

- Runtime: unchanged (uses existing selenium , webdriver-manager , etc.).
- Dev-only: requirements-dev.txt adds pytest , pytest-asyncio , pytest-cov , pip-tools , pip-audit , safety , black , isort , and build .
Fixes # (issue)

- N/A (please link a related issue if applicable)
## Type of change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
# How Has This Been Tested?
Local validation on Windows with Python 3.14:

- Unit tests: pytest -q → 29 passed, warnings only (UTC deprecation).
- REST flow end-to-end:
  - python run_enroller.py --debug --email <EMAIL> --password <PASSWORD>
  - Enrollments and RunStatistics printed; cookies persisted atomically.
- UI flow with automatic fallback:
  - python run_enroller.py --browser chrome --debug --email <EMAIL> --password <PASSWORD>
  - If login fields are not accessible due to site protections, runner falls back to REST and completes successfully.
- Dev scripts:
  - .\scripts\setup.ps1 initializes venv and installs deps
  - .\scripts\run-rest.ps1 -Debug runs REST
  - .\scripts\run-ui.ps1 -Browser chrome -Debug runs UI with fallback
  - .\scripts\test.ps1 installs dev deps and runs tests
Please also try:

- Test A: pytest -q and review coverage ( coverage.xml generated)
- Test B: Run UI with credentials and observe fallback behavior in logs
# Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings (unit tests show non-blocking UTC deprecation advisory only)
- Any dependent changes have been merged and published in downstream modules
- I have added tests that prove my fix is effective or that my feature works (Optional)
- New and existing unit tests pass locally with my changes (Optional)
Notes:

- No breaking changes; existing entrypoints remain; RunConfig introduced as a stable wrapper.
- UI automation remains subject to anti-bot measures; this PR adds robust fallback to ensure successful execution.