### PR TITLE
Improve course ID extraction from Udemy pages

### DIFF
--- a/udemy_enroller/udemy_rest.py
+++ b/udemy_enroller/udemy_rest.py
@@ -418,9 +418,59 @@ class UdemyActions:
         """
         response = requests.get(url)
         response.raise_for_status()
+
+        html_text = response.text
         soup = BeautifulSoup(response.content, "html.parser")
 
-        return int(soup.find("body")["data-clp-course-id"])
+        # Primary: course pages usually set this attribute on <body>
+        body = soup.find("body")
+        if body and body.has_attr("data-clp-course-id"):
+            return int(body["data-clp-course-id"])
+
+        # Fallback: search the HTML for the attribute (some variants omit it from the parsed <body>)
+        match = re.search(r'data-clp-course-id=["\'](\d+)["\']', html_text)
+        if match:
+            return int(match.group(1))
+
+        # Fallback: some Udemy variants (behind Cloudflare JS challenges)
+        # hide data-clp-course-id but still include the course id in Udemy CDN image URLs.
+        # Example: https://img-c.udemycdn.com/course/480x270/<COURSE_ID>_....jpg
+        candidates = []
+
+        for key, value in (("property", "og:image"), ("name", "image")):
+            tag = soup.find("meta", {key: value})
+            if tag and tag.get("content"):
+                candidates.append(tag.get("content"))
+
+        for link in soup.find_all("link", {"as": "image"}):
+            if link.get("href"):
+                candidates.append(link.get("href"))
+            # Some pages use imageSrcSet/imagesrcset
+            for srcset_key in ("imageSrcSet", "imagesrcset"):
+                if link.get(srcset_key):
+                    candidates.append(link.get(srcset_key))
+
+        for img in soup.find_all("img"):
+            if img.get("src"):
+                candidates.append(img.get("src"))
+            for srcset_key in ("srcset", "srcSet"):
+                if img.get(srcset_key):
+                    candidates.append(img.get(srcset_key))
+
+        for candidate in candidates:
+            if not candidate:
+                continue
+            m = re.search(r"/course/\d+x\d+/(\d+)_", candidate)
+            if m:
+                return int(m.group(1))
+
+        # Last resort: regex over full HTML
+        m = re.search(r"/course/\d+x\d+/(\d+)_", html_text)
+        if m:
+            return int(m.group(1))
+
+        # Preserve previous behavior
+        raise KeyError("data-clp-course-id")
 
     def _checkout(
         self,


### PR DESCRIPTION
# Description

Updated _get_course_id() in udemy_enroller/udemy_rest.py to support multiple extraction choices:

Primary: body["data-clp-course-id"] (existing)

Fallback: regex search for data-clp-course-id="..." in the HTML

Fallback: extract the course id from Udemy CDN course image URLs (e.g. /course/480x270/<COURSE_ID>_...jpg) found in meta/link/img locations and, as a last resort, in the full HTML.

Seems like certain course URL's can sometimes return a bot protection variant page where <body> only has dir="ltr" and does not include data-clp-course-id, even though the course id is still present elsewhere in the HTML. This causes failed enrollment and leads to repeated “Unexpected exception: 'data-clp-course-id'” errors making you miss 70% of enrollments.

Fixes # N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run the enroller normally; enrollment no longer fails on pages that lack data-clp-course-id.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have added tests that prove my fix is effective or that my feature works (Optional)
- [ ] New and existing unit tests pass locally with my changes (Optional)
